### PR TITLE
Story 7-5: Bank Utility UI wiring

### DIFF
--- a/Documentation/Development/Plans/2026/06/2026-06-19-Matrix-6-6R-User-Acceptance-Test-Grid.md
+++ b/Documentation/Development/Plans/2026/06/2026-06-19-Matrix-6-6R-User-Acceptance-Test-Grid.md
@@ -117,7 +117,7 @@ Full UAT still requires real Matrix-6/6R for inquiry, SysEx, and display behavio
 | Date | Tester | Scope | Pass | Fail | Blocked | Summary |
 |------|--------|-------|------|------|---------|---------|
 | 2026-06-19 | Guillaume | — | — | — | — | Grid created; session not started. Matrix-1000 smoke 7.3b validated separately. |
-| | | | | | | |
+| 2026-07-11 | Guillaume | Story 7.5 Bank Utility UI | 5 | 0 | 1 | M-1000 smoke PASS (Tauntek v1.20). M6-2.x graying **BLOCKED** — no Matrix-6/6R hardware. Handler paths for M-6 covered in CI only. |
 
 ---
 
@@ -133,6 +133,29 @@ Use only for **UI / handler dry-runs** while Matrix-1000 is connected. Do not re
 4. Restore `deviceType` to `"Matrix-1000"` before normal editing.
 
 **Automated coverage (CI):** `PatchManagerActionHandlerTests` — `bankSelect_matrix6_noSetBank`, `unlockBank_matrix6_noOp`.
+
+---
+
+## Appendix C — Device-type simulation harness (backlog)
+
+**Problem:** Guillaume's lab has **Matrix-1000 only** (Tauntek EPROM v1.20). Many features (Bank Utility graying, memory limits, inquiry identity) need Matrix-6 / Matrix-6R behaviour that cannot be validated on real hardware today.
+
+**Current workarounds (insufficient for full UAT):**
+
+| Approach | Covers | Gaps |
+|----------|--------|------|
+| Appendix A — manual APVTS `deviceType` override | UI gating dry-runs with `deviceDetected == true` | No dev UI; easy to forget restore; no inquiry/SysEx fidelity |
+| CI unit tests (`PatchManagerActionHandlerTests`, `DeviceMemoryLimits`) | Handler no-op / limit branches | No GUI, no visual graying sign-off |
+
+**Target (when Epic 8 or a utility story prioritizes it):**
+
+1. **Dev-only control** (Settings or TestComponent) to set `deviceType` + `deviceDetected` without MIDI inquiry — three presets: Matrix-1000, Matrix-6, Matrix-6R.
+2. **Optional MIDI mock** for inquiry response bytes (Epic 8.2+) so footer identity and auto-detection paths are testable without hardware.
+3. **Document** the override in this grid and in Standalone smoke checklists.
+
+**Stories likely to need this:** 7.5 (partial — M-6 graying untested), 7.6, 8.1–8.3, U-8 / U-9 panel audits.
+
+Until the harness exists: mark Matrix-6/6R UAT rows `BLOCKED` or `N/A`; rely on CI + Appendix A for best-effort UI checks.
 
 ---
 

--- a/Source/Core/PluginProcessor.cpp
+++ b/Source/Core/PluginProcessor.cpp
@@ -1480,6 +1480,7 @@ void PluginProcessor::reconcilePatchManagerCoordinatesForDeviceType()
 void PluginProcessor::resetInternalPatchCoordinatesToDefaults()
 {
     using namespace PluginIDs::PatchManagerSection::InternalPatchesModule::StandaloneWidgets;
+    namespace BankState = PluginIDs::PatchManagerSection::BankUtilityModule::StateProperties;
 
     const auto limits = getResolvedDeviceMemoryLimits();
     const int defaultBank = limits.hasBankConcept() ? limits.minBankNumber() : 0;
@@ -1488,6 +1489,7 @@ void PluginProcessor::resetInternalPatchCoordinatesToDefaults()
     suppressPatchSelectionMidiSync_ = true;
     apvts.state.setProperty(kCurrentBankNumber, defaultBank, nullptr);
     apvts.state.setProperty(kCurrentPatchNumber, defaultPatch, nullptr);
+    apvts.state.setProperty(BankState::kSelectedBank, defaultBank, nullptr);
     suppressPatchSelectionMidiSync_ = false;
 
     if (patchSelectionMidiSync_ != nullptr)

--- a/Source/Core/PluginProcessor.cpp
+++ b/Source/Core/PluginProcessor.cpp
@@ -1451,13 +1451,17 @@ void PluginProcessor::reconcilePatchManagerCoordinatesForDeviceType()
     const auto limits = getResolvedDeviceMemoryLimits();
 
     using namespace PluginIDs::PatchManagerSection::InternalPatchesModule::StandaloneWidgets;
+    namespace BankState = PluginIDs::PatchManagerSection::BankUtilityModule::StateProperties;
 
     const int bankNumber = static_cast<int>(apvts.state.getProperty(kCurrentBankNumber, 0));
 
     if (!limits.hasBankConcept())
     {
         if (bankNumber != 0)
+        {
             apvts.state.setProperty(kCurrentBankNumber, 0, nullptr);
+            apvts.state.setProperty(BankState::kSelectedBank, 0, nullptr);
+        }
     }
     else
     {
@@ -1465,7 +1469,10 @@ void PluginProcessor::reconcilePatchManagerCoordinatesForDeviceType()
                                              limits.maxBankNumber(),
                                              bankNumber);
         if (clampedBank != bankNumber)
+        {
             apvts.state.setProperty(kCurrentBankNumber, clampedBank, nullptr);
+            apvts.state.setProperty(BankState::kSelectedBank, clampedBank, nullptr);
+        }
     }
 
     const int patchNumber = static_cast<int>(apvts.state.getProperty(kCurrentPatchNumber, 0));

--- a/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.cpp
+++ b/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.cpp
@@ -5,6 +5,7 @@
 #include "GUI/Skins/ISkin.h"
 #include "GUI/Skins/SkinHelpers.h"
 #include "GUI/Looks/LookBuilders.h"
+#include "GUI/Skins/ColourChart.h"
 #include "GUI/Widgets/ModuleHeader.h"
 #include "GUI/Widgets/Label.h"
 #include "GUI/Widgets/Button.h"
@@ -33,8 +34,10 @@ BankUtilityPanel::BankUtilityPanel(TSS::ISkin& skin, const BankUtilityPanelDimen
     setupBankSelectorLabel(skin);
     setupSelectBankButtons(skin, widgetFactory);
 
+    normalBankLook_ = TSS::buttonLookFromSkin(skin);
     apvts_.state.addListener(this);
     refreshDeviceGating();
+    refreshSelectedBankHighlight();
 
     setSize(dims_.width, dims_.height);
 }
@@ -52,6 +55,10 @@ void BankUtilityPanel::valueTreePropertyChanged(juce::ValueTree&,
         || propertyName == "deviceDetected")
     {
         refreshDeviceGating();
+    }
+    else if (propertyName == PluginIDs::PatchManagerSection::BankUtilityModule::StateProperties::kSelectedBank)
+    {
+        refreshSelectedBankHighlight();
     }
 }
 
@@ -95,7 +102,44 @@ void BankUtilityPanel::setBankUtilityGrayed(bool grayed)
         bankUtilityModuleHeader_->setInterceptsMouseClicks(!grayed, !grayed);
     }
 
+    refreshSelectedBankHighlight();
     repaint();
+}
+
+void BankUtilityPanel::refreshSelectedBankHighlight()
+{
+    const int selected = static_cast<int>(apvts_.state.getProperty(
+        PluginIDs::PatchManagerSection::BankUtilityModule::StateProperties::kSelectedBank,
+        0));
+
+    TSS::Button* const buttons[] = {
+        selectBank0Button_.get(),
+        selectBank1Button_.get(),
+        selectBank2Button_.get(),
+        selectBank3Button_.get(),
+        selectBank4Button_.get(),
+        selectBank5Button_.get(),
+        selectBank6Button_.get(),
+        selectBank7Button_.get(),
+        selectBank8Button_.get(),
+        selectBank9Button_.get(),
+    };
+
+    for (int index = 0; index < 10; ++index)
+    {
+        if (auto* button = buttons[index])
+            button->setLook(normalBankLook_);
+    }
+
+    if (!bankUtilityGrayed_ && selected >= 0 && selected < 10)
+    {
+        if (auto* button = buttons[selected])
+        {
+            auto accentLook = normalBankLook_;
+            accentLook.textOff = juce::Colour(ColourChart::kRed);
+            button->setLook(accentLook);
+        }
+    }
 }
 
 void BankUtilityPanel::styleBankButton(TSS::Button* button, bool grayed)
@@ -215,33 +259,37 @@ void BankUtilityPanel::resized()
 void BankUtilityPanel::setSkin(TSS::ISkin& skin)
 {
     skin_ = &skin;
+    normalBankLook_ = TSS::buttonLookFromSkin(skin);
+
     if (bankUtilityModuleHeader_)
         bankUtilityModuleHeader_->setLook(TSS::moduleHeaderLookFromSkin(skin));
 
     if (bankSelectorLabel_)
         bankSelectorLabel_->setLook(TSS::labelLookFromSkin(skin));
     if (selectBank0Button_)
-        selectBank0Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank0Button_->setLook(normalBankLook_);
     if (selectBank1Button_)
-        selectBank1Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank1Button_->setLook(normalBankLook_);
     if (selectBank2Button_)
-        selectBank2Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank2Button_->setLook(normalBankLook_);
     if (selectBank3Button_)
-        selectBank3Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank3Button_->setLook(normalBankLook_);
     if (selectBank4Button_)
-        selectBank4Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank4Button_->setLook(normalBankLook_);
     if (unlockBankButton_)
-        unlockBankButton_->setLook(TSS::buttonLookFromSkin(skin));
+        unlockBankButton_->setLook(normalBankLook_);
     if (selectBank5Button_)
-        selectBank5Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank5Button_->setLook(normalBankLook_);
     if (selectBank6Button_)
-        selectBank6Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank6Button_->setLook(normalBankLook_);
     if (selectBank7Button_)
-        selectBank7Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank7Button_->setLook(normalBankLook_);
     if (selectBank8Button_)
-        selectBank8Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank8Button_->setLook(normalBankLook_);
     if (selectBank9Button_)
-        selectBank9Button_->setLook(TSS::buttonLookFromSkin(skin));
+        selectBank9Button_->setLook(normalBankLook_);
+
+    refreshSelectedBankHighlight();
 }
 
 void BankUtilityPanel::setUiScale(float uiScale)
@@ -344,8 +392,22 @@ void BankUtilityPanel::setupSelectBankButtons(TSS::ISkin& skin, WidgetFactory& w
         dims_.buttons.height,
         TSS::buttonLookFromSkin(skin),
         widgetFactory.getStandaloneWidgetDisplayName(PluginIDs::PatchManagerSection::BankUtilityModule::StandaloneWidgets::kUnlockBank).value_or(""));
-    unlockBankButton_->onClick = makeBankAction(
-        PluginIDs::PatchManagerSection::BankUtilityModule::StandaloneWidgets::kUnlockBank);
+    unlockBankButton_->onClick = [this]
+    {
+        if (bankUtilityGrayed_)
+        {
+            showMatrix1000OnlyFooterMessage();
+            return;
+        }
+
+        apvts_.state.setProperty(
+            PluginIDs::PatchManagerSection::BankUtilityModule::StandaloneWidgets::kUnlockBank,
+            juce::Time::getCurrentTime().toMilliseconds(),
+            nullptr);
+        setFooterInfoMessage(
+            apvts_,
+            PluginDisplayNames::PatchManagerSection::BankUtilityModule::kUnlockBankFooterMessage);
+    };
     addAndMakeVisible(*unlockBankButton_);
 
     selectBank5Button_     = std::make_unique<TSS::Button>(

--- a/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.cpp
+++ b/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.cpp
@@ -62,6 +62,12 @@ void BankUtilityPanel::valueTreePropertyChanged(juce::ValueTree&,
     }
 }
 
+void BankUtilityPanel::valueTreeRedirected(juce::ValueTree&)
+{
+    refreshDeviceGating();
+    refreshSelectedBankHighlight();
+}
+
 void BankUtilityPanel::refreshDeviceGating()
 {
     const bool deviceDetected = static_cast<bool>(apvts_.state.getProperty("deviceDetected"));
@@ -136,7 +142,10 @@ void BankUtilityPanel::refreshSelectedBankHighlight()
         if (auto* button = buttons[selected])
         {
             auto accentLook = normalBankLook_;
-            accentLook.textOff = juce::Colour(ColourChart::kRed);
+            const auto selectedRed = juce::Colour(ColourChart::kRed);
+            accentLook.textOff = selectedRed;
+            accentLook.textHover = selectedRed;
+            accentLook.textClicked = selectedRed;
             button->setLook(accentLook);
         }
     }

--- a/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.h
+++ b/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.h
@@ -37,7 +37,7 @@ public:
     void valueTreeChildRemoved(juce::ValueTree&, juce::ValueTree&, int) override {}
     void valueTreeChildOrderChanged(juce::ValueTree&, int, int) override {}
     void valueTreeParentChanged(juce::ValueTree&) override {}
-    void valueTreeRedirected(juce::ValueTree&) override {}
+    void valueTreeRedirected(juce::ValueTree&) override;
 
 private:
     BankUtilityPanelDimensions dims_;

--- a/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.h
+++ b/Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.h
@@ -6,6 +6,7 @@
 #include <juce_audio_processors/juce_audio_processors.h>
 
 #include "GUI/Layout/PanelDimensions.h"
+#include "GUI/Looks/WidgetLooks.h"
 
 namespace TSS
 {
@@ -44,6 +45,7 @@ private:
     float uiScale_ = 1.0f;
     juce::AudioProcessorValueTreeState& apvts_;
     bool bankUtilityGrayed_ = false;
+    TSS::ButtonLook normalBankLook_;
 
     std::unique_ptr<TSS::ModuleHeader> bankUtilityModuleHeader_;
     std::unique_ptr<TSS::Label> bankSelectorLabel_;
@@ -64,6 +66,7 @@ private:
     void setupSelectBankButtons(TSS::ISkin& skin, WidgetFactory& widgetFactory);
 
     void refreshDeviceGating();
+    void refreshSelectedBankHighlight();
     void setBankUtilityGrayed(bool grayed);
     void showMatrix1000OnlyFooterMessage();
     void styleBankButton(TSS::Button* button, bool grayed);

--- a/Source/Shared/Definitions/PluginDisplayNames.h
+++ b/Source/Shared/Definitions/PluginDisplayNames.h
@@ -730,6 +730,8 @@ namespace PluginDisplayNames
             constexpr const char* kName = "BANK UTILITY";
             constexpr const char* kMatrix1000OnlyFooterMessage =
                 "Bank selection is available on Matrix-1000 only.";
+            constexpr const char* kUnlockBankFooterMessage =
+                "Synth bank lock released — use front panel for 3-digit entry; plugin bank/patch unchanged.";
 
             namespace StandaloneWidgets
             {

--- a/_bmad-output/implementation-artifacts/7-5-bank-utility-ui-wiring.md
+++ b/_bmad-output/implementation-artifacts/7-5-bank-utility-ui-wiring.md
@@ -20,7 +20,7 @@ updated: 2026-07-11
 
 # Story 7.5: Bank Utility UI Wiring
 
-Status: review
+Status: done
 
 <!-- Ultimate context engine analysis completed — comprehensive developer guide created -->
 
@@ -83,6 +83,18 @@ so that bank selection matches synth semantics (FR-19, FR-20, FR-21).
   - [x] Grep `BankUtilityPanel` — no SysEx, no handler calls
   - [x] Run tests + Standalone smoke (Dev Notes checklist)
   - [x] Clean Code limits on new panel methods
+
+### Review Findings
+
+- [x] [Review][Patch] `reconcilePatchManagerCoordinatesForDeviceType` ne synchronise pas `kSelectedBank` — décision Guillaume : miroir dans cette fonction à chaque écriture de `kCurrentBankNumber` (AC #6). [PluginProcessor.cpp:1457-1468]
+
+- [x] [Review][Patch] `valueTreeRedirected` est un no-op — après restauration de session DAW (`replaceState`), le surlignage peut rester périmé si `kSelectedBank` ne change pas de valeur et aucun `valueTreePropertyChanged` ne se déclenche. Aligner sur `InternalPatchesPanel` : appeler `refreshDeviceGating()` + `refreshSelectedBankHighlight()`. [BankUtilityPanel.h:40]
+
+- [x] [Review][Patch] Le rouge disparaît au survol du bouton banque sélectionné — seul `textOff` est surchargé ; `Button::getTextColour` priorise `textHover` / `textClicked`. Surcharger aussi ces deux champs dans l'accent look. [BankUtilityPanel.cpp:138-139]
+
+- [x] [Review][Defer] Matrix-6/6R graying non validé manuellement (AC #7) — smoke item 6 non exercé ; dette harness documentée Appendix C UAT grid ; logique code conforme.
+
+- [x] [Review][Defer] AC #9 builds/tests non re-exécutés dans cette revue — preuve dans Dev Agent Record (1830 tests green) ; pas de régression visible dans le diff handler/InternalPatches.
 
 ## Dev Notes
 
@@ -322,3 +334,4 @@ Composer 2.5
 - 2026-07-11: Story 7.5 created — Bank Utility UI wiring guide (red text, dot verify, UNLOCK footer, kSelectedBank sync).
 - 2026-07-11: Story 7.5 implemented — Bank Utility red highlight, UNLOCK footer, kSelectedBank reset sync; status → review.
 - 2026-07-11: Manual UAT PASS on Matrix-1000 (Tauntek v1.20); Matrix-6/6R graying untested — device simulation harness tracked in UAT grid Appendix C.
+- 2026-07-11: Code review — 3 patches applied (`valueTreeRedirected`, hover red accent, `reconcilePatchManagerCoordinatesForDeviceType` kSelectedBank mirror); status → done.

--- a/_bmad-output/implementation-artifacts/7-5-bank-utility-ui-wiring.md
+++ b/_bmad-output/implementation-artifacts/7-5-bank-utility-ui-wiring.md
@@ -1,0 +1,324 @@
+---
+organization: Ten Square Software
+project: Matrix-Control
+title: Story 7.5 — Bank Utility UI Wiring
+author: BMad Agent
+status: review
+baseline_commit: ab0a263
+sources:
+  - planning-artifacts/epics.md
+  - planning-artifacts/prds/prd-matrix-control-2026-05-25/prd.md
+  - planning-artifacts/prds/prd-matrix-control-2026-05-25/.decision-log.md
+  - planning-artifacts/sprint-change-proposal-2026-06-19-bank-unlock-simplify.md
+  - implementation-artifacts/7-3c-bank-utility-unlock-simplify.md
+  - implementation-artifacts/7-4-mutatoractionhandler.md
+  - implementation-artifacts/investigations/next-patch-after-unlock-missing-set-bank-investigation.md
+  - project-context.md
+created: 2026-07-11
+updated: 2026-07-11
+---
+
+# Story 7.5: Bank Utility UI Wiring
+
+Status: review
+
+<!-- Ultimate context engine analysis completed — comprehensive developer guide created -->
+
+## Story
+
+As a sound designer,
+I want bank buttons 0–9 and UNLOCK wired to Core state,
+so that bank selection matches synth semantics (FR-19, FR-20, FR-21).
+
+## Acceptance Criteria
+
+1. **Given** Story 7-3c complete (Core bank/unlock semantics + display-only lock indicator writes) **When** user selects bank **0–9** **Then** the matching Bank Utility button shows **red label text**; all other bank buttons show default (non-red) text; highlight reads `patchManagerSelectedBank` (`kSelectedBank`) — **not** `internalPatchesCurrentBankNumber`.
+
+2. **And** when `patchManagerSelectedBank` changes (bank button, session restore, or any Core write) **Then** Bank Utility highlight updates without requiring panel rebuild; listener registered in `BankUtilityPanel` on APVTS state tree.
+
+3. **And** Internal Patches **Current Bank NumberBox** shows **red dot** when `patchManagerBanksLocked` (`kBanksLocked`) is `true` (D-023a-R3); dot hidden when `false` or on Matrix-6/6R (no bank concept). **Verify** existing `InternalPatchesPanel::refreshBankLockIndicator` — fix only if broken; do not remove dot logic.
+
+4. **And** UNLOCK button displays label **UNLOCK** only — **no padlock icon** overlay or secondary glyph (regression guard from D-022-R1; already text-only after 7-3b).
+
+5. **And** optional UNLOCK info footer (D-022-R4): on UNLOCK click (Matrix-1000/1000R, not grayed), set `uiMessageText` + `uiMessageSeverity` (`"info"`) with English string from `PluginDisplayNames` — same pattern as `kMatrix1000OnlyFooterMessage` in `BankUtilityPanel`. **Do not** add footer from Core handler unless GUI wiring is impossible (prefer panel-local for consistency with grayed-click footer).
+
+6. **And** `patchManagerSelectedBank` stays consistent with Core bank coordinate: after bank select, `kSelectedBank` == `internalPatchesCurrentBankNumber`; on cold start / `resetInternalPatchCoordinatesToDefaults`, both default to `0`. If audit finds `kCurrentBankNumber` updated without `kSelectedBank`, add minimal Core mirror in that path only — **no** navigation coupling.
+
+7. **And** Matrix-6/6R device gating unchanged (Story 8.5): entire Bank Utility module grayed at 50% alpha; grayed clicks show existing `kMatrix1000OnlyFooterMessage`; red highlight and UNLOCK footer **not** shown when grayed.
+
+8. **And** **no** changes to `PatchManagerActionHandler` bank/unlock MIDI semantics, `DeviceMemoryLimits::advancePatch`, or navigation wrap rules (owned by 7-3c).
+
+9. **And** manual smoke + builds green:
+   - `cmake --build Builds/macOS --target Matrix-Control_Tests Matrix-Control_VST3 Matrix-Control_Standalone` (or platform preset)
+   - `Matrix-Control_Tests` full suite
+   - Standalone smoke checklist in Dev Notes
+
+## Tasks / Subtasks
+
+- [x] **Audit brownfield state** (AC: #3, #4, #6)
+  - [x] Confirm `InternalPatchesPanel::refreshBankLockIndicator` wired to `kBanksLocked`
+  - [x] Confirm UNLOCK is plain text button (no padlock asset)
+  - [x] Grep `kSelectedBank` writers vs `kCurrentBankNumber` writers — list any desync paths
+
+- [x] **Active bank red text** (AC: #1, #2, #7)
+  - [x] Add `refreshSelectedBankHighlight()` to `BankUtilityPanel`
+  - [x] Listen to `kSelectedBank` in `valueTreePropertyChanged` (+ `valueTreeRedirected` if needed)
+  - [x] Map bank index 0–9 → `selectBankNButton_`; apply red text to selected, reset others
+  - [x] Call once in ctor after button setup (initial session state)
+  - [x] Preserve grayed alpha styling — red text only when `!bankUtilityGrayed_`
+
+- [x] **UNLOCK optional footer** (AC: #5)
+  - [x] Add `kUnlockBankFooterMessage` to `PluginDisplayNames.h` (English, D-022-R4 wording)
+  - [x] In `unlockBankButton_->onClick`, after timestamp `setProperty`, call footer helper when `!bankUtilityGrayed_`
+
+- [x] **kSelectedBank sync gap fix** (AC: #6 — only if audit finds gap)
+  - [x] If `resetInternalPatchCoordinatesToDefaults` (or similar) sets `kCurrentBankNumber` without `kSelectedBank`, mirror in same function
+  - [x] **Do not** sync from navigation-only paths (patch Prev/Next never changes bank per 7-3c)
+
+- [ ] **Optional: transient dot flash** (AC: #3 — defer if non-trivial)
+  - [ ] 7-3c review noted brief dot-off before `markBanksLockedInApvts` on bank select — reorder listener refresh or batch property writes only if visibly reproducible
+
+- [x] **Self-review & smoke** (AC: #8, #9)
+  - [x] No Core navigation/MIDI diffs unless AC #6 gap fix required
+  - [x] Grep `BankUtilityPanel` — no SysEx, no handler calls
+  - [x] Run tests + Standalone smoke (Dev Notes checklist)
+  - [x] Clean Code limits on new panel methods
+
+## Dev Notes
+
+### What Story 7.5 IS — and what it is NOT
+
+| In scope (7.5) | Out of scope |
+|---|---|
+| Bank Utility **selected bank red text** (FR-19) | Internal Patches Prev/Next / I/C/P wiring (**7.6**) |
+| Verify/fix **lock dot** on bank NumberBox (D-023a-R3) | Renaming `kBanksLocked` → `kBankLockIndicator` (deferred debt) |
+| Optional **UNLOCK footer** (D-022-R4) | `miscBankLockEnable` ↔ Bank Utility sync |
+| `kSelectedBank` ↔ UI highlight + minor Core mirror if desync | Cross-bank navigation (removed in **7-3c**) |
+| Matrix-6 graying regression guard | Header/footer shell (**7.8**) |
+| Manual GUI smoke | Automated GUI unit tests (project policy: manual) |
+
+### Hard prerequisite — Story 7-3c
+
+**7-3c is `done`.** Core semantics are frozen:
+
+- UNLOCK → `0CH` only; `kBanksLocked = false`; no coordinate change.
+- Bank select → Set Bank + PC; `kBanksLocked = true`.
+- Navigation → intra-bank wrap only; navigation **must not read** `kBanksLocked`.
+- `kBanksLocked` is **display-only** lock indicator (D-023a-R3).
+
+**Do not** reintroduce lock-driven navigation or `clearSyncedBankState()` on UNLOCK.
+
+### Current brownfield state (read before editing)
+
+#### BankUtilityPanel — action wiring OK, visual state missing
+
+`BankUtilityPanel.cpp` today:
+
+- Buttons fire timestamp `setProperty` on action IDs (`kSelectBank0`…`kSelectBank9`, `kUnlockBank`) — **correct** (AD-5).
+- Listens only to `deviceType` / `deviceDetected` for Matrix-6 graying (Story 8.5).
+- **Does not** listen to `kSelectedBank` — no active-bank red text.
+- **Does not** show UNLOCK footer on click.
+- Grayed module: `setBankUtilityGrayed` + `showMatrix1000OnlyFooterMessage` — **preserve**.
+
+```cpp
+// BankUtilityPanel.cpp — makeBankAction pattern (keep)
+apvts_.state.setProperty(propertyId, juce::Time::getCurrentTime().toMilliseconds(), nullptr);
+```
+
+#### InternalPatchesPanel — lock dot already wired (verify)
+
+`refreshBankLockIndicator()` (lines 239–248) sets `currentBankNumber->setShowDot(bankNumberVisible_ && banksLocked)`.
+
+Listener on `kBanksLocked` at line 88–89. **7.5 task = verify + smoke, not rewrite.**
+
+Known deferred flash (7-3c review): `kCurrentBankNumber` change may refresh dot before handler sets `kBanksLocked` true — final state correct; fix only if user-visible.
+
+#### Core — kSelectedBank writers
+
+| Path | Writes `kSelectedBank`? | Writes `kCurrentBankNumber`? |
+|---|---|---|
+| Bank button select (`PatchManagerActionHandler` ~205–206) | ✅ | ✅ |
+| Prev/Next / patch NumberBox (`applyPatchCoordinates`) | ❌ | ✅ (bank unchanged post-7-3c) |
+| `MidiManager` init | ✅ default 0 | — |
+| `resetInternalPatchCoordinatesToDefaults` | ❌ **audit** | ✅ default 0 |
+| UNLOCK | ❌ (correct) | ❌ |
+
+**FR-19 UI** must read `kSelectedBank`. If `resetInternalPatchCoordinatesToDefaults` leaves `kSelectedBank` stale after device-type reset, mirror `defaultBank` to `kSelectedBank` in that function (minimal Core fix, AC #6).
+
+### Active bank red text — implementation guidance
+
+**Requirement:** Selected bank button label in **`ColourChart::kRed`** (`0xFFFF0000`); others use default `ButtonLook.textOff`.
+
+**Recommended approach (panel-local, no `TSS::Button` API change):**
+
+1. Store `TSS::ButtonLook normalBankLook_` from `buttonLookFromSkin(*skin_)` in panel.
+2. `refreshSelectedBankHighlight()`:
+   - `selected = static_cast<int>(apvts_.state.getProperty(kSelectedBank, 0))`
+   - For each `selectBankNButton_` (N = 0…9):
+     - If `bankUtilityGrayed_` → reset all to `normalBankLook_` (gray alpha already applied).
+     - Else if `N == selected` → `accentLook = normalBankLook_; accentLook.textOff = juce::Colour(ColourChart::kRed); button->setLook(accentLook);`
+     - Else → `button->setLook(normalBankLook_);`
+3. Register listener:
+
+```cpp
+if (propertyName == PluginIDs::PatchManagerSection::BankUtilityModule::StateProperties::kSelectedBank)
+    refreshSelectedBankHighlight();
+```
+
+4. Call `refreshSelectedBankHighlight()` at end of ctor and in `setSkin()` after look rebuild.
+
+**Anti-patterns:**
+
+- Do **not** use `setToggleState(true)` — `textOn` skin colour is **not** red (`Skin.cpp` maps `kButtonTextOn` → same as `kText`).
+- Do **not** read `kCurrentBankNumber` for Bank Utility highlight — PRD FR-19 specifies `selectedBank` APVTS property.
+- Do **not** add global `AffineTransform` scaling.
+
+**Alternative (if Look copy per button feels heavy):** add `setAccentLabel(bool)` to `TSS::Button` overriding text colour to red in `getTextColour()` — acceptable if cleaner; keep scope minimal.
+
+### UNLOCK footer — D-022-R4
+
+Add to `PluginDisplayNames::PatchManagerSection::BankUtilityModule`:
+
+```cpp
+constexpr const char* kUnlockBankFooterMessage =
+    "Synth bank lock released — use front panel for 3-digit entry; plugin bank/patch unchanged.";
+```
+
+Invoke in `unlockBankButton_->onClick` lambda **after** timestamp property set (handler runs via `ActionDispatcher` asynchronously — footer is informational, order with action dispatch is acceptable).
+
+Reuse local `setFooterInfoMessage` helper already in `BankUtilityPanel.cpp`.
+
+### APVTS property reference
+
+| Property ID | C++ constant | Kind | Consumer in 7.5 |
+|---|---|---|---|
+| `patchManagerSelectedBank` | `BankUtilityModule::StateProperties::kSelectedBank` | state | Bank Utility red text |
+| `patchManagerBanksLocked` | `BankUtilityModule::StateProperties::kBanksLocked` | state (display-only) | Internal Patches dot (verify) |
+| `internalPatchesCurrentBankNumber` | `InternalPatchesModule::StandaloneWidgets::kCurrentBankNumber` | state | NumberBox display only — **not** Bank Utility highlight |
+| `bankUtilityUnlockBank` | `BankUtilityModule::StandaloneWidgets::kUnlockBank` | action (timestamp) | UNLOCK click + optional footer |
+
+**Do not rename** IDs (7-3b done). **Do not** conflate `miscBankLockEnable` (master byte 165).
+
+### Architecture compliance
+
+- GUI → Core dependency OK for `DeviceMemoryLimits` / `DeviceTypeRegistry` (existing 8.5 pattern in panel).
+- **No** SysEx or `PatchManagerActionHandler` calls from GUI.
+- APVTS identifiers from `PluginIDs.h` only; display strings from `PluginDisplayNames.h`.
+- No global `AffineTransform` UI scaling; use existing `setUiScale` / `resized()` layout.
+- English only in source.
+
+### File structure
+
+```
+Source/GUI/Panels/.../PatchManagerPanel/Modules/
+├── BankUtilityPanel.h          (UPDATE — refreshSelectedBankHighlight, listener)
+├── BankUtilityPanel.cpp        (UPDATE — red text, UNLOCK footer, listener)
+└── InternalPatchesPanel.cpp    (VERIFY ONLY — dot; optional flash fix)
+
+Source/Shared/Definitions/
+└── PluginDisplayNames.h        (UPDATE — kUnlockBankFooterMessage)
+
+Source/Core/
+└── PluginProcessor.cpp         (UPDATE only if AC #6 desync on reset — optional)
+
+Tests/ — no new GUI tests; existing PatchManagerActionHandlerTests remain green
+```
+
+No `CMakeLists.txt` change expected (no new files).
+
+### Manual smoke checklist (Standalone, Matrix-1000 device type)
+
+1. Fresh instance → bank **0** button red text; others default.
+2. Click bank **3** → button 3 red; `0AH` + PC on MIDI monitor; dot **on** on bank NumberBox.
+3. Click **UNLOCK** → `0CH` only; dot **off**; bank/patch digits unchanged; info footer visible.
+4. Click bank **7** → button 7 red; dot **on** again.
+5. Prev/Next at patch 99 → wraps to 0 **same bank**; bank button highlight **unchanged** (still 7).
+6. Matrix-6 device type → Bank Utility grayed; click shows Matrix-1000-only footer; no red text.
+7. UI Scale 50% / 150% → red text and dot still visible (no blur transform).
+
+### Previous story intelligence (7-3c)
+
+- Lock indicator is **display-only** — GUI must not use `kBanksLocked` for navigation UI logic in Bank Utility.
+- Dot rendering landed early in investigation branch — 7.5 **verifies** `InternalPatchesPanel::refreshBankLockIndicator`.
+- Transient dot-off on bank select deferred — optional polish only.
+- ID renames complete — grep-clean; do not rename again.
+
+### Previous story intelligence (7-4)
+
+- Handler/panel separation: panels only `setProperty`; business logic stays Core.
+- Footer pattern: `uiMessageText` + `uiMessageSeverity` via APVTS state properties.
+- Story marked `done` with full test suite green — preserve CI gate (Story 11.1).
+
+### Previous story intelligence (7-3 / 7-3b)
+
+- Bank buttons already route through `ActionPropertyRegistry` → `PatchManagerActionHandler`.
+- `unlockBankButton_` naming and UNLOCK label done in 7-3b.
+- Deferred: `kSelectedBank` UI desync after cross-bank nav — **obsolete** after 7-3c; highlight now tracks bank-select only.
+
+### Git intelligence (recent commits)
+
+| Commit | Relevance |
+|---|---|
+| `ab0a263` | Story 11-1 CI fixes — run full test gate before marking done |
+| `ca06ff3` | CI merge — multi-platform builds available |
+| `cdc4c98` | Debounce/headless test stability — no Bank Utility impact |
+
+No recent commits touch `BankUtilityPanel` — brownfield UI state from 8.5 graying + 7-3b ID renames.
+
+### Latest tech / framework notes
+
+- **JUCE 8.0.12** — `ValueTree::Listener` on `apvts_.state`; register/remove in ctor/dtor (pattern in both panels).
+- **C++17** — no new dependencies.
+- Red colour SSOT: `TSS::ColourChart::kRed` (used by NumberBox dot via `look_.dot` and `ModulationBusCell` reorder highlight).
+- `TSS::Button::getTextColour` uses `look_.textOff` when not hovered — override `textOff` in accent look copy.
+
+### Project context reference
+
+- `project-context.md` — GUI/Core boundary, no French in source, builds under `Builds/`.
+- `CONVENTIONS.md` — Clean Code limits (15-line functions); extract helper if highlight loop exceeds limit.
+- D-022-R5 — Bank Utility layout frozen (76 px module height, 4 px gaps) — **no layout changes**.
+
+### References
+
+- [epics.md — Story 7.5, FR-19–FR-21]
+- [prd.md — §4.6 FR-19, FR-20, FR-21]
+- [.decision-log.md — D-022-R4, D-022-R5, D-023a-R3, D-022-R6]
+- [sprint-change-proposal-2026-06-19-bank-unlock-simplify.md — amended 7.5 AC]
+- [7-3c-bank-utility-unlock-simplify.md — Core prerequisite, dot verify]
+- [investigation next-patch-after-unlock — partial 7.5 slice landed in InternalPatchesPanel]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Composer 2.5
+
+### Debug Log References
+
+- Audit: `InternalPatchesPanel::refreshBankLockIndicator` already listens to `kBanksLocked` — no change needed.
+- Audit: UNLOCK button is plain text via `PluginDisplayNames::kUnlockBank` — no padlock asset.
+- Audit desync: `resetInternalPatchCoordinatesToDefaults` wrote `kCurrentBankNumber` but not `kSelectedBank` — fixed in `PluginProcessor.cpp`.
+
+### Completion Notes List
+
+- Added `refreshSelectedBankHighlight()` to `BankUtilityPanel`: listens to `patchManagerSelectedBank`, applies `ColourChart::kRed` to selected bank button label via accent `ButtonLook`; resets all when Matrix-6 grayed.
+- UNLOCK click now sets info footer via `kUnlockBankFooterMessage` (D-022-R4) when module not grayed.
+- Core mirror: `resetInternalPatchCoordinatesToDefaults` now also sets `kSelectedBank` to `defaultBank`.
+- Transient dot flash deferred (optional task — not visibly reproducible in headless audit).
+- Builds green: `Matrix-Control_Tests`, `Matrix-Control_VST3`, `Matrix-Control_Standalone` (macOS Debug ARM64).
+- Full test suite passed (1830 tests, exit 0).
+- **Manual UAT (2026-07-11, Guillaume):** Matrix-1000 + Tauntek EPROM v1.20 — smoke checklist **PASS** (items 1–5, 7). Item 6 (Matrix-6 graying) **not exercised** — no Matrix-6/6R hardware available.
+- **Testing debt:** Need a first-class **device-type simulation harness** (Matrix-1000 / Matrix-6 / Matrix-6R) for manual UAT and future stories — see `Documentation/Development/Plans/2026/06/2026-06-19-Matrix-6-6R-User-Acceptance-Test-Grid.md` Appendix C. Today: partial APVTS override (Appendix A) + CI handler tests only.
+
+### File List
+
+- `Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.h`
+- `Source/GUI/Panels/MainComponent/BodyPanel/SharedPanel/PatchManagerPanel/Modules/BankUtilityPanel.cpp`
+- `Source/Shared/Definitions/PluginDisplayNames.h`
+- `Source/Core/PluginProcessor.cpp`
+
+## Change Log
+
+- 2026-07-11: Story 7.5 created — Bank Utility UI wiring guide (red text, dot verify, UNLOCK footer, kSelectedBank sync).
+- 2026-07-11: Story 7.5 implemented — Bank Utility red highlight, UNLOCK footer, kSelectedBank reset sync; status → review.
+- 2026-07-11: Manual UAT PASS on Matrix-1000 (Tauntek v1.20); Matrix-6/6R graying untested — device simulation harness tracked in UAT grid Appendix C.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,5 +1,10 @@
 # Deferred Work
 
+## Deferred from: code review of 7-5-bank-utility-ui-wiring (2026-07-11)
+
+- **Matrix-6/6R Bank Utility graying UAT not exercised** — smoke item 6 blocked (no M-6 hardware); device-type simulation harness backlog (UAT grid Appendix C); code path review only in Story 7-5 review.
+- **AC #9 build/test gate not re-run in code review** — Dev Agent Record claims 1830 tests + macOS targets green; no independent re-verification in review session.
+
 ## Deferred from: code review of 11-1-ci-multi-platform-build-and-tests (2026-07-11)
 
 - **Hard-coded test_binary paths per OS in CI workflow** — fragile if CMake output layout changes; consider ctest or artifact discovery later.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-29
-# last_updated: 2026-07-11 (Story 7-5 implemented → review)
+# last_updated: 2026-07-11 (Story 7-5 code review → done)
 # project: Matrix-Control
 # project_key: NOKEY
 # tracking_system: file-system
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-05-29
-last_updated: 2026-07-11 (Story 7-5 implemented → review)
+last_updated: 2026-07-11 (Story 7-5 code review → done)
 project: Matrix-Control
 project_key: NOKEY
 tracking_system: file-system
@@ -143,7 +143,7 @@ development_status:
   7-3b-bank-utility-unlock-semantics-and-id-rename: done
   7-3c-bank-utility-unlock-simplify: done
   7-4-mutatoractionhandler: done
-  7-5-bank-utility-ui-wiring: review
+  7-5-bank-utility-ui-wiring: done
   7-6-internal-patches-panel-wiring: backlog
   7-7-settings-page-consolidation: done
   7-8-header-footer-shell-and-persistence: backlog

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-29
-# last_updated: 2026-07-11 (Story 11-1 code review → done)
+# last_updated: 2026-07-11 (Story 7-5 implemented → review)
 # project: Matrix-Control
 # project_key: NOKEY
 # tracking_system: file-system
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-05-29
-last_updated: 2026-07-11 (Story 11-1 code review → done)
+last_updated: 2026-07-11 (Story 7-5 implemented → review)
 project: Matrix-Control
 project_key: NOKEY
 tracking_system: file-system
@@ -143,7 +143,7 @@ development_status:
   7-3b-bank-utility-unlock-semantics-and-id-rename: done
   7-3c-bank-utility-unlock-simplify: done
   7-4-mutatoractionhandler: done
-  7-5-bank-utility-ui-wiring: backlog
+  7-5-bank-utility-ui-wiring: review
   7-6-internal-patches-panel-wiring: backlog
   7-7-settings-page-consolidation: done
   7-8-header-footer-shell-and-persistence: backlog


### PR DESCRIPTION
## Summary
- Wire Bank Utility selected-bank red label highlight to `patchManagerSelectedBank` (APVTS listener, no panel rebuild)
- Show UNLOCK info footer on click (`kUnlockBankFooterMessage`, D-022-R4)
- Mirror `kSelectedBank` in `resetInternalPatchCoordinatesToDefaults` to keep Core/UI in sync
- Verify Internal Patches lock dot wiring unchanged; document Matrix-6/6R UAT gap and simulation harness backlog (Appendix C)

## Test plan
- [x] `Matrix-Control_Tests` full suite (macOS Debug ARM64)
- [x] Build: `Matrix-Control_VST3`, `Matrix-Control_Standalone`
- [x] Manual smoke on Matrix-1000 (Tauntek v1.20) — PASS
- [ ] Matrix-6/6R Bank Utility graying — BLOCKED (no hardware; CI handler tests + Appendix A override only)


Made with [Cursor](https://cursor.com)