### PR TITLE
Add tag-triggered CD release pipeline (Story 11-2)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,7 @@ env:
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -98,11 +99,14 @@ jobs:
             -DUSER_COPY_TO_ARTEFACTS_DIR=OFF
 
       - name: Build plugin and unit tests
-        run: >
-          cmake --build --preset "${{ matrix.preset }}"
-          --target Matrix-Control Matrix-Control_Tests
-          ${{ matrix.build_config }}
+        shell: bash
+        run: |
+          cmake --build --preset "${{ matrix.preset }}" \
+            --target Matrix-Control Matrix-Control_Tests \
+            ${{ matrix.build_config }}
 
       - name: Run unit tests
         shell: bash
-        run: '"${{ matrix.test_binary }}"'
+        run: |
+          test -f "${{ matrix.test_binary }}"
+          "${{ matrix.test_binary }}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,7 +23,20 @@ env:
   JUCE_VERSION: "8.0.12"
 
 jobs:
+  release-script-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout Matrix-Control
+        uses: actions/checkout@v4
+
+      - name: Run release script unit tests
+        run: |
+          python3 -m pip install -r Scripts/release/requirements-test.txt
+          python3 -m pytest Scripts/release/tests/ -q
+
   build-and-test:
+    needs: release-script-tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,305 @@
+# Tag-triggered Release build, sign (macOS), package, and GitHub Release (Story 11.2).
+#
+# Preset choices (CMakeUserPresets.json):
+#   macOS  — macos-release-arm64   (Apple Silicon runner = macos-latest)
+#   Windows — windows-release        (VS 2026)
+#   Linux  — linux-release          (Ninja)
+#
+# CI overrides:
+#   -DMATRIX_BUILD_TESTS=ON
+#   -DUSER_COPY_TO_SYSTEM_FOLDERS=OFF
+#   -DUSER_COPY_TO_ARTEFACTS_DIR=OFF
+#   -DMATRIX_CONTROL_PRERELEASE_SUFFIX=<from tag suffix, empty for stable>
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  JUCE_VERSION: "8.0.12"
+
+jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+      version: ${{ steps.tag.outputs.version }}
+      suffix: ${{ steps.tag.outputs.suffix }}
+    steps:
+      - name: Checkout Matrix-Control
+        uses: actions/checkout@v4
+
+      - name: Validate semver tag and CMake version
+        id: tag
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          python3 Scripts/release/prepare_release.py validate-tag "$TAG"
+          PARSED=$(python3 -c "
+          import sys
+          sys.path.insert(0, 'Scripts/release')
+          from prepare_release import parse_version_from_tag
+          parsed = parse_version_from_tag('${TAG}')
+          print(parsed.display_version)
+          print(parsed.suffix)
+          ")
+          VERSION=$(echo "$PARSED" | sed -n '1p')
+          SUFFIX=$(echo "$PARSED" | sed -n '2p')
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "suffix=$SUFFIX" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION (tag: $TAG)"
+
+  build:
+    needs: validate-tag
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            platform: macos
+            preset: macos-release-arm64
+            build_config: ""
+            archive_suffix: macOS-arm64
+            pack_extra: --arch arm64
+            test_binary: Builds/macOS/ARM/Release/Matrix-Control_Tests_artefacts/Release/Matrix-Control_Tests
+            artefacts_root: Builds/macOS/ARM/Release/Matrix-Control_artefacts/Release
+          - os: windows-latest
+            platform: windows
+            preset: windows-release
+            build_config: --config Release
+            archive_suffix: Windows
+            pack_extra: ""
+            test_binary: Builds/Windows/Matrix-Control_Tests_artefacts/Release/Matrix-Control_Tests.exe
+            artefacts_root: Builds/Windows/Matrix-Control_artefacts/Release
+          - os: ubuntu-latest
+            platform: linux
+            preset: linux-release
+            build_config: ""
+            archive_suffix: Linux
+            pack_extra: ""
+            test_binary: Builds/Linux/Release/Matrix-Control_Tests_artefacts/Release/Matrix-Control_Tests
+            artefacts_root: Builds/Linux/Release/Matrix-Control_artefacts/Release
+
+    steps:
+      - name: Checkout Matrix-Control
+        uses: actions/checkout@v4
+
+      - name: Cache JUCE
+        id: cache-juce
+        uses: actions/cache@v4
+        with:
+          path: JUCE
+          key: juce-${{ env.JUCE_VERSION }}-${{ runner.os }}
+
+      - name: Checkout JUCE
+        if: steps.cache-juce.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: juce-framework/JUCE
+          ref: ${{ env.JUCE_VERSION }}
+          path: JUCE
+
+      - name: Install Linux build dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libasound2-dev \
+            libjack-jackd2-dev \
+            ladspa-sdk \
+            libcurl4-openssl-dev \
+            libfreetype6-dev \
+            libfontconfig1-dev \
+            libx11-dev \
+            libxcomposite-dev \
+            libxcursor-dev \
+            libxext-dev \
+            libxinerama-dev \
+            libxrandr-dev \
+            libxrender-dev \
+            libglu1-mesa-dev \
+            mesa-common-dev \
+            libglib2.0-dev
+
+      - name: Configure CMake (Release)
+        shell: bash
+        env:
+          JUCE_DIR: ${{ github.workspace }}/JUCE
+        run: |
+          cmake --preset "${{ matrix.preset }}" \
+            -DMATRIX_BUILD_TESTS=ON \
+            -DUSER_COPY_TO_SYSTEM_FOLDERS=OFF \
+            -DUSER_COPY_TO_ARTEFACTS_DIR=OFF \
+            -DMATRIX_CONTROL_PRERELEASE_SUFFIX="${{ needs.validate-tag.outputs.suffix }}"
+
+      - name: Build plugin and unit tests
+        shell: bash
+        run: |
+          cmake --build --preset "${{ matrix.preset }}" \
+            --target Matrix-Control Matrix-Control_Tests \
+            ${{ matrix.build_config }}
+
+      - name: Run unit tests
+        shell: bash
+        run: |
+          test -f "${{ matrix.test_binary }}"
+          "${{ matrix.test_binary }}"
+
+      - name: Require macOS signing secrets
+        if: matrix.platform == 'macos'
+        shell: bash
+        env:
+          DEV_ID_APP_CERT: ${{ secrets.DEV_ID_APP_CERT }}
+          DEV_ID_APP_PASSWORD: ${{ secrets.DEV_ID_APP_PASSWORD }}
+          DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+          NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
+          NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=0
+          for var in DEV_ID_APP_CERT DEV_ID_APP_PASSWORD DEVELOPER_ID_APPLICATION NOTARIZATION_USERNAME NOTARIZATION_PASSWORD APPLE_TEAM_ID; do
+            if [ -z "${!var}" ]; then
+              echo "Missing required secret: $var"
+              missing=1
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "macOS release builds require codesign + notarization secrets (see CONTRIBUTING.md)."
+            exit 1
+          fi
+
+      - name: Import signing certificate (macOS)
+        if: matrix.platform == 'macos'
+        uses: sudara/basic-macos-keychain-action@v1
+        id: keychain
+        with:
+          dev-id-app-cert: ${{ secrets.DEV_ID_APP_CERT }}
+          dev-id-app-password: ${{ secrets.DEV_ID_APP_PASSWORD }}
+
+      - name: Codesign and notarize (macOS)
+        if: matrix.platform == 'macos'
+        timeout-minutes: 30
+        shell: bash
+        env:
+          DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+          NOTARIZATION_USERNAME: ${{ secrets.NOTARIZATION_USERNAME }}
+          NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          ROOT="${{ matrix.artefacts_root }}"
+          VST3="$ROOT/VST3/Matrix-Control.vst3"
+          AU="$ROOT/AU/Matrix-Control.component"
+          APP="$ROOT/Standalone/Matrix-Control.app"
+          for path in "$VST3" "$AU" "$APP"; do
+            test -d "$path" || { echo "Missing bundle: $path"; exit 1; }
+          done
+
+          sign_bundle() {
+            codesign --force --keychain "${{ steps.keychain.outputs.keychain-path }}" \
+              -s "$DEVELOPER_ID_APPLICATION" \
+              --deep --strict --options=runtime --timestamp \
+              "$1"
+            codesign --verify --deep --strict --verbose=2 "$1"
+          }
+
+          sign_bundle "$VST3"
+          sign_bundle "$AU"
+          sign_bundle "$APP"
+
+          NOTARY_DIR=$(mktemp -d)
+          notarize_and_staple() {
+            local bundle="$1"
+            local zip="$NOTARY_DIR/$(basename "$bundle").zip"
+            ditto -c -k --keepParent "$bundle" "$zip"
+            xcrun notarytool submit "$zip" \
+              --apple-id "$NOTARIZATION_USERNAME" \
+              --password "$NOTARIZATION_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait
+            xcrun stapler staple "$bundle"
+          }
+
+          notarize_and_staple "$VST3"
+          notarize_and_staple "$AU"
+          notarize_and_staple "$APP"
+
+      - name: Pack platform release archive
+        shell: bash
+        run: |
+          python3 Scripts/release/prepare_release.py \
+            --tag "${{ needs.validate-tag.outputs.tag }}" \
+            --force \
+            pack "${{ matrix.platform }}" \
+            --artefacts-root "${{ matrix.artefacts_root }}" \
+            ${{ matrix.pack_extra }}
+
+      - name: Upload platform archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform }}-archive
+          path: _local/releases/${{ needs.validate-tag.outputs.version }}/Matrix-Control-v${{ needs.validate-tag.outputs.version }}-${{ matrix.archive_suffix }}.zip
+          retention-days: 7
+
+  publish:
+    needs: [validate-tag, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout Matrix-Control
+        uses: actions/checkout@v4
+
+      - name: Download platform archives
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Assemble release directory
+        shell: bash
+        env:
+          VERSION: ${{ needs.validate-tag.outputs.version }}
+        run: |
+          RELEASE_DIR="_local/releases/${VERSION}"
+          mkdir -p "$RELEASE_DIR"
+          for platform in linux macos windows; do
+            src=$(find "artifacts/${platform}-archive" -maxdepth 1 -name "Matrix-Control-v${VERSION}-*.zip" -print -quit)
+            if [ -z "$src" ] || [ ! -f "$src" ]; then
+              echo "Missing platform archive for ${platform}: expected Matrix-Control-v${VERSION}-*.zip"
+              exit 1
+            fi
+            cp "$src" "$RELEASE_DIR/"
+          done
+          ls -la "$RELEASE_DIR"
+
+      - name: Finalize and publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.validate-tag.outputs.tag }}
+        shell: bash
+        run: |
+          python3 Scripts/release/prepare_release.py \
+            --tag "$TAG" \
+            --force \
+            finalize
+          python3 Scripts/release/prepare_release.py \
+            --tag "$TAG" \
+            publish-ci --yes

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ build/
 
 # Cache directories
 .cache/
+__pycache__/
+*.py[cod]
 
 # Xcode
 *.xcodeproj

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for your interest in Matrix-Control! Whether you are a JUCE developer,
 - [Reporting Bugs](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#reporting-bugs)
 - [Suggesting Features](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#suggesting-features)
 - [Contributing Code](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#contributing-code)
-- [Continuous Integration](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#continuous-integration)
+- [Continuous Integration](#continuous-integration)
 - [Code Style Guidelines](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#code-style-guidelines)
 - [Commit Message Convention](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#commit-message-convention)
 - [Pull Request Process](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#pull-request-process)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Thank you for your interest in Matrix-Control! Whether you are a JUCE developer,
 - [Suggesting Features](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#suggesting-features)
 - [Contributing Code](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#contributing-code)
 - [Continuous Integration](#continuous-integration)
+- [Releasing](#releasing)
 - [Code Style Guidelines](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#code-style-guidelines)
 - [Commit Message Convention](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#commit-message-convention)
 - [Pull Request Process](https://claude.ai/chat/16b5619a-506c-4e52-9a86-10a1574ec048#pull-request-process)
@@ -158,6 +159,70 @@ cmake --preset linux-debug \
   -DUSER_COPY_TO_ARTEFACTS_DIR=OFF
 cmake --build --preset linux-debug --target Matrix-Control Matrix-Control_Tests
 "Builds/Linux/Debug/Matrix-Control_Tests_artefacts/Debug/Matrix-Control_Tests"
+```
+
+------
+
+## Releasing
+
+Public downloads are published via **GitHub Releases**, triggered by pushing a semver **git tag** (not by merging to `main`).
+
+### Version source of truth
+
+1. Bump `project(Matrix-Control VERSION X.Y.Z)` in `CMakeLists.txt`.
+2. Set `MATRIX_CONTROL_PRERELEASE_SUFFIX`:
+   - **Stable release:** empty string (`""`) — required for `v1.0.0`.
+   - **Pre-release:** suffix matching the tag (e.g. `rc1` for `v1.0.0-rc1`, `alpha` for `v0.2.0-alpha`).
+3. Commit, then create an **annotated tag** with a **`v` prefix** matching the version + suffix:
+   - Stable: `git tag -a v1.0.0 -m "Matrix-Control 1.0.0"`
+   - RC: `git tag -a v1.0.0-rc1 -m "Matrix-Control 1.0.0-rc1"`
+4. Push the tag: `git push origin v1.0.0-rc1`
+
+The [Release](https://github.com/tensquaresoftware/matrix-control/actions/workflows/release.yml) workflow validates the tag against `CMakeLists.txt`, builds **Release** binaries on macOS / Windows / Linux, runs unit tests, packages per-OS zips, and publishes a GitHub Release.
+
+### Recommended flow (RC → stable)
+
+1. Clear blockers (e.g. Epic U-10 release gate — no `TestComponent` in Release builds).
+2. Bump version + set suffix (e.g. `rc1`), tag `vX.Y.Z-rc1`, push tag.
+3. Download assets from the GitHub Release; smoke-test on each OS (DAW + standalone).
+4. For stable: set `MATRIX_CONTROL_PRERELEASE_SUFFIX=""`, commit, tag `vX.Y.Z`, push tag.
+
+### Required GitHub secrets (macOS signing)
+
+Configure in **Settings → Secrets and variables → Actions** (names only — never commit values):
+
+| Secret | Purpose |
+|--------|---------|
+| `DEV_ID_APP_CERT` | Base64-encoded `.p12` Developer ID Application certificate |
+| `DEV_ID_APP_PASSWORD` | Password for the `.p12` |
+| `DEVELOPER_ID_APPLICATION` | Codesign identity name (e.g. `Developer ID Application: …`) |
+| `NOTARIZATION_USERNAME` | Apple ID for notarytool |
+| `NOTARIZATION_PASSWORD` | App-specific password for notarytool |
+| `APPLE_TEAM_ID` | Apple Developer Team ID |
+
+The macOS release leg **fails** if any of these are missing — there is no silent skip of signing/notarization.
+
+**Windows Authenticode** signing is optional for v1 (unsigned VST3/Standalone is acceptable for MIT open-source distribution).
+
+### Local packaging (fallback)
+
+If CI is unavailable, build Release locally and pack with:
+
+```bash
+cmake --preset macos-release-arm64 \
+  -DMATRIX_BUILD_TESTS=ON \
+  -DUSER_COPY_TO_SYSTEM_FOLDERS=OFF \
+  -DUSER_COPY_TO_ARTEFACTS_DIR=OFF \
+  -DMATRIX_CONTROL_PRERELEASE_SUFFIX=""
+cmake --build --preset macos-release-arm64 --target Matrix-Control
+python3 Scripts/release/prepare_release.py --tag v1.0.0 pack macos --arch arm64
+```
+
+Release script unit tests:
+
+```bash
+python3 -m pip install -r Scripts/release/requirements-test.txt
+python3 -m pytest Scripts/release/tests/ -q
 ```
 
 ------

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The project is actively under development. As of early 2026:
 
 - ✅ Project structure and build system (CMake) are in place
 - ✅ CI pipeline (GitHub Actions) — multi-platform build + Core unit tests on push/PR to `main`
+- ✅ CD pipeline — tag-triggered Release builds and [GitHub Releases](https://github.com/tensquaresoftware/matrix-control/releases)
 - ✅ Core MIDI infrastructure (SysEx parsing, validation, sending) is functional
 - ✅ GUI layout and visual design are well advanced
 - 🔄 Full patch editing (read/write all Matrix-1000 parameters) — in progress

--- a/Scripts/release/prepare_release.py
+++ b/Scripts/release/prepare_release.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+"""Prepare and publish Matrix-Control GitHub releases (JUCE AU/VST3/Standalone)."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+TEMPLATE_DIR = SCRIPT_DIR / "templates"
+GITHUB_REPO = "tensquaresoftware/matrix-control"
+RELEASES_ROOT = PROJECT_ROOT / "_local" / "releases"
+CHECKSUM_FILE = "SHA256SUMS.txt"
+NOTES_FILE = "RELEASE_NOTES.md"
+PRODUCT_NAME = "Matrix-Control"
+
+TAG_PATTERN = re.compile(
+    r"^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<suffix>.+))?$"
+)
+CMAKE_VERSION_PATTERN = re.compile(
+    r"project\s*\(\s*Matrix-Control\s+VERSION\s+(\d+\.\d+\.\d+)\s*\)",
+    re.MULTILINE,
+)
+CMAKE_SUFFIX_PATTERN = re.compile(
+    r'set\s*\(\s*MATRIX_CONTROL_PRERELEASE_SUFFIX\s+"([^"]*)"',
+    re.MULTILINE,
+)
+
+PLATFORM_ASSETS = ("macos", "windows", "linux")
+
+
+@dataclass(frozen=True)
+class ParsedTag:
+    raw: str
+    base_version: str
+    suffix: str
+
+    @property
+    def display_version(self) -> str:
+        if self.suffix:
+            return f"{self.base_version}-{self.suffix}"
+        return self.base_version
+
+
+@dataclass(frozen=True)
+class CMakeVersion:
+    version: str
+    prerelease_suffix: str
+
+
+@dataclass(frozen=True)
+class ReleasePaths:
+    version: str
+    release_dir: Path
+
+    def platform_archive(self, platform: str, *, arch: str = "arm64") -> Path:
+        if platform == "macos":
+            return self.release_dir / f"{PRODUCT_NAME}-v{self.version}-macOS-{arch}.zip"
+        if platform == "windows":
+            return self.release_dir / f"{PRODUCT_NAME}-v{self.version}-Windows.zip"
+        if platform == "linux":
+            return self.release_dir / f"{PRODUCT_NAME}-v{self.version}-Linux.zip"
+        raise ValueError(f"Unknown platform: {platform!r}")
+
+    @property
+    def checksums(self) -> Path:
+        return self.release_dir / CHECKSUM_FILE
+
+    @property
+    def notes(self) -> Path:
+        return self.release_dir / NOTES_FILE
+
+    def distributable_archives(self) -> tuple[Path, ...]:
+        return tuple(
+            path
+            for path in sorted(self.release_dir.glob(f"{PRODUCT_NAME}-v{self.version}-*.zip"))
+            if path.is_file()
+        )
+
+
+@dataclass(frozen=True)
+class ArtefactPaths:
+    vst3: Path
+    au: Path | None
+    standalone: Path
+
+
+def parse_version_from_tag(tag: str) -> ParsedTag:
+    match = TAG_PATTERN.match(tag)
+    if not match:
+        raise ValueError(
+            f"Unsupported tag: {tag!r} (expected vX.Y.Z or vX.Y.Z-suffix)"
+        )
+    base = f"{match.group('major')}.{match.group('minor')}.{match.group('patch')}"
+    suffix = match.group("suffix") or ""
+    return ParsedTag(raw=tag, base_version=base, suffix=suffix)
+
+
+def is_prerelease_tag(tag: str) -> bool:
+    return bool(parse_version_from_tag(tag).suffix)
+
+
+def read_cmake_version(root: Path = PROJECT_ROOT) -> CMakeVersion:
+    text = (root / "CMakeLists.txt").read_text(encoding="utf-8")
+    version_match = CMAKE_VERSION_PATTERN.search(text)
+    suffix_match = CMAKE_SUFFIX_PATTERN.search(text)
+    if not version_match:
+        raise SystemExit("Could not read project(Matrix-Control VERSION …) from CMakeLists.txt")
+    if suffix_match is None:
+        raise SystemExit(
+            "Could not read MATRIX_CONTROL_PRERELEASE_SUFFIX from CMakeLists.txt"
+        )
+    return CMakeVersion(
+        version=version_match.group(1),
+        prerelease_suffix=suffix_match.group(1),
+    )
+
+
+def validate_tag_against_cmake(tag: str, root: Path = PROJECT_ROOT) -> ParsedTag:
+    parsed = parse_version_from_tag(tag)
+    cmake = read_cmake_version(root)
+    if parsed.base_version != cmake.version:
+        raise SystemExit(
+            f"Tag base version {parsed.base_version} does not match "
+            f"CMakeLists.txt VERSION {cmake.version}"
+        )
+    if parsed.suffix != cmake.prerelease_suffix:
+        raise SystemExit(
+            f"Tag suffix {parsed.suffix!r} does not match "
+            f"MATRIX_CONTROL_PRERELEASE_SUFFIX {cmake.prerelease_suffix!r}"
+        )
+    return parsed
+
+
+def default_artefact_roots(platform: str) -> Path:
+    if platform == "macos":
+        return PROJECT_ROOT / "Builds/macOS/ARM/Release/Matrix-Control_artefacts/Release"
+    if platform == "windows":
+        return PROJECT_ROOT / "Builds/Windows/Matrix-Control_artefacts/Release"
+    if platform == "linux":
+        return (
+            PROJECT_ROOT
+            / "Builds/Linux/Release/Matrix-Control_artefacts/Release"
+        )
+    raise ValueError(f"Unknown platform: {platform!r}")
+
+
+def discover_artefact_paths(
+    platform: str,
+    *,
+    artefacts_root: Path | None = None,
+) -> ArtefactPaths:
+    root = artefacts_root or default_artefact_roots(platform)
+    vst3 = root / "VST3" / f"{PRODUCT_NAME}.vst3"
+    standalone = root / "Standalone" / (
+        f"{PRODUCT_NAME}.app" if platform == "macos" else f"{PRODUCT_NAME}.exe"
+        if platform == "windows"
+        else PRODUCT_NAME
+    )
+    au = root / "AU" / f"{PRODUCT_NAME}.component" if platform == "macos" else None
+
+    missing: list[str] = []
+    for label, path in (
+        ("VST3", vst3),
+        ("Standalone", standalone),
+        *((("AU", au),) if au is not None else ()),
+    ):
+        if not path.exists():
+            missing.append(f"{label}: {path}")
+        elif path.is_dir() and not any(path.rglob("*")):
+            missing.append(f"{label} (empty bundle): {path}")
+
+    if missing:
+        raise SystemExit(
+            "Missing build artefacts:\n  " + "\n  ".join(missing)
+        )
+
+    return ArtefactPaths(vst3=vst3, au=au, standalone=standalone)
+
+
+def render_template(name: str, version: str) -> str:
+    path = TEMPLATE_DIR / name
+    if not path.is_file():
+        raise SystemExit(f"Missing template: {path}")
+    return path.read_text(encoding="utf-8").replace("{{VERSION}}", version)
+
+
+def ensure_release_dir(paths: ReleasePaths) -> None:
+    paths.release_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _add_path_to_zip(zf: zipfile.ZipFile, source: Path, arc_prefix: Path) -> None:
+    if source.is_dir():
+        for item in sorted(source.rglob("*")):
+            if item.is_dir():
+                continue
+            arcname = arc_prefix / item.relative_to(source)
+            zf.write(item, arcname=str(arcname).replace("\\", "/"))
+    else:
+        zf.write(source, arcname=str(arc_prefix / source.name).replace("\\", "/"))
+
+
+def pack_platform(
+    paths: ReleasePaths,
+    platform: str,
+    *,
+    artefacts_root: Path | None = None,
+    arch: str = "arm64",
+    force: bool = False,
+) -> Path:
+    archive = paths.platform_archive(platform, arch=arch)
+    if archive.is_file() and not force:
+        raise SystemExit(f"Archive already exists: {archive}\nUse --force to overwrite.")
+
+    artefacts = discover_artefact_paths(platform, artefacts_root=artefacts_root)
+    ensure_release_dir(paths)
+    if archive.is_file():
+        archive.unlink()
+
+    print(f"Packing {platform} -> {archive.name}")
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("README.txt", render_template("RELEASE_NOTES.template.md", paths.version))
+        _add_path_to_zip(zf, artefacts.vst3, Path(""))
+        if artefacts.au is not None:
+            _add_path_to_zip(zf, artefacts.au, Path(""))
+        _add_path_to_zip(zf, artefacts.standalone, Path(""))
+
+    size_mb = archive.stat().st_size / (1024 * 1024)
+    print(f"  Created {archive} ({size_mb:.1f} MiB)")
+    return archive
+
+
+def import_archive(
+    paths: ReleasePaths,
+    platform: str,
+    source: Path,
+    *,
+    arch: str = "arm64",
+    force: bool = False,
+) -> None:
+    if platform not in PLATFORM_ASSETS:
+        raise SystemExit(f"Unknown platform: {platform!r}")
+
+    source = source.resolve()
+    if not source.is_file():
+        raise SystemExit(f"Source file not found: {source}")
+
+    target = paths.platform_archive(platform, arch=arch)
+    if target.is_file() and not force:
+        raise SystemExit(f"Archive already exists: {target}\nUse --force to overwrite.")
+
+    ensure_release_dir(paths)
+    shutil.copy2(source, target)
+    print(f"Imported {source.name} -> {target}")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_release_notes(paths: ReleasePaths, *, force: bool = False) -> None:
+    if paths.notes.is_file() and not force:
+        print(f"{NOTES_FILE} already exists (use --force to overwrite)")
+        return
+    ensure_release_dir(paths)
+    paths.notes.write_text(
+        render_template("RELEASE_NOTES.template.md", paths.version),
+        encoding="utf-8",
+    )
+    print(f"Created {paths.notes.name}")
+
+
+def write_checksums(paths: ReleasePaths) -> None:
+    archives = paths.distributable_archives()
+    if not archives:
+        raise SystemExit("Cannot write checksums — no platform archives found")
+
+    lines = [f"{sha256_file(path)}  {path.name}" for path in archives]
+    ensure_release_dir(paths)
+    paths.checksums.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"Created {paths.checksums.name}")
+
+
+def verify_release(paths: ReleasePaths) -> None:
+    errors: list[str] = []
+    archives = paths.distributable_archives()
+    if not archives:
+        errors.append("No platform archives found")
+
+    required_archives = {
+        paths.platform_archive(platform).name for platform in PLATFORM_ASSETS
+    }
+    present_archives = {path.name for path in archives}
+    missing_archives = sorted(required_archives - present_archives)
+    if missing_archives:
+        errors.append(
+            "Missing required platform archives: " + ", ".join(missing_archives)
+        )
+
+    for path in archives:
+        if path.stat().st_size == 0:
+            errors.append(f"Empty archive: {path.name}")
+
+    if not paths.notes.is_file():
+        errors.append(f"Missing {NOTES_FILE}")
+
+    if not paths.checksums.is_file():
+        errors.append(f"Missing {CHECKSUM_FILE}")
+    else:
+        listed_names = set()
+        for line in paths.checksums.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            parts = line.split(maxsplit=1)
+            if len(parts) != 2:
+                errors.append(f"Invalid checksum line: {line!r}")
+                continue
+            expected, name = parts
+            listed_names.add(name)
+            file_path = paths.release_dir / name
+            if not file_path.is_file():
+                errors.append(f"Checksum references missing file: {name}")
+                continue
+            if sha256_file(file_path) != expected:
+                errors.append(f"Checksum mismatch: {name}")
+
+        missing_checksums = sorted(present_archives - listed_names)
+        if missing_checksums:
+            errors.append(
+                "Archives missing from checksums: " + ", ".join(missing_checksums)
+            )
+
+    if errors:
+        print("Verification FAILED:")
+        for err in errors:
+            print(f"  * {err}")
+        raise SystemExit(1)
+
+    print("Verification OK — all archives present and checksums match.")
+
+
+def status(paths: ReleasePaths) -> None:
+    ensure_release_dir(paths)
+    print(f"Version    : {paths.version}")
+    print(f"Release dir: {paths.release_dir}")
+    print()
+    for platform in PLATFORM_ASSETS:
+        path = paths.platform_archive(platform)
+        if path.is_file():
+            size = path.stat().st_size / (1024 * 1024)
+            print(f"  [OK] {platform:7} {path.name} ({size:.1f} MiB)")
+        else:
+            print(f"  [ ] {platform:7} {path.name}")
+    for label, path in (("Checksums", paths.checksums), ("Notes", paths.notes)):
+        if path.is_file():
+            print(f"  [OK] {label:7} {path.name}")
+        else:
+            print(f"  [ ] {label:7} {path.name}")
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None) -> None:
+    print("==>", " ".join(str(part) for part in cmd))
+    subprocess.run(cmd, cwd=cwd or PROJECT_ROOT, check=True)
+
+
+def _gh_release_exists(tag: str) -> bool:
+    result = subprocess.run(
+        ["gh", "release", "view", tag, "--repo", GITHUB_REPO],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def build_gh_release_create_cmd(
+    paths: ReleasePaths,
+    tag: str,
+    *,
+    prerelease: bool,
+) -> list[str]:
+    assets = [*[str(p) for p in paths.distributable_archives()], str(paths.checksums)]
+    cmd = [
+        "gh",
+        "release",
+        "create",
+        tag,
+        "--repo",
+        GITHUB_REPO,
+        "--title",
+        f"{PRODUCT_NAME} {paths.version}",
+        "--notes-file",
+        str(paths.notes),
+        *assets,
+    ]
+    if prerelease:
+        cmd.append("--prerelease")
+    return cmd
+
+
+def gh_release_create(
+    paths: ReleasePaths,
+    tag: str,
+    *,
+    prerelease: bool,
+) -> None:
+    verify_release(paths)
+    if not paths.notes.is_file():
+        raise SystemExit(f"Missing {NOTES_FILE}. Run: prepare_release.py finalize")
+
+    assets = [*[str(p) for p in paths.distributable_archives()], str(paths.checksums)]
+
+    if _gh_release_exists(tag):
+        print(f"Release {tag} already exists — uploading assets")
+        _run(
+            ["gh", "release", "upload", tag, "--repo", GITHUB_REPO, *assets, "--clobber"],
+            cwd=paths.release_dir,
+        )
+        edit_cmd = [
+            "gh",
+            "release",
+            "edit",
+            tag,
+            "--repo",
+            GITHUB_REPO,
+            "--notes-file",
+            str(paths.notes),
+        ]
+        if prerelease:
+            edit_cmd.append("--prerelease")
+        else:
+            edit_cmd.append("--prerelease=false")
+        _run(edit_cmd, cwd=paths.release_dir)
+    else:
+        _run(build_gh_release_create_cmd(paths, tag, prerelease=prerelease), cwd=paths.release_dir)
+
+    print()
+    print(f"Published: https://github.com/{GITHUB_REPO}/releases/tag/{tag}")
+
+
+def publish_ci(
+    paths: ReleasePaths,
+    tag: str,
+    *,
+    yes: bool,
+    prerelease: bool | None = None,
+) -> None:
+    resolved_prerelease = (
+        prerelease if prerelease is not None else is_prerelease_tag(tag)
+    )
+
+    print()
+    print(f"Ready to publish {PRODUCT_NAME} {paths.version} (CI — tag must already exist)")
+    print(f"  Tag   : {tag}")
+    print(f"  Assets: {paths.release_dir}")
+    print(f"  Notes : {paths.notes.name}")
+    if resolved_prerelease:
+        print("  Mode  : pre-release")
+    print()
+
+    if not yes:
+        answer = input("Continue? [y/N] ").strip().lower()
+        if answer not in {"y", "yes"}:
+            print("Aborted.")
+            return
+
+    gh_release_create(paths, tag, prerelease=resolved_prerelease)
+
+
+def build_paths(version: str | None, *, tag: str | None = None) -> ReleasePaths:
+    if tag:
+        parsed = parse_version_from_tag(tag)
+        resolved = parsed.display_version
+    elif version:
+        resolved = version
+    else:
+        cmake = read_cmake_version()
+        suffix = cmake.prerelease_suffix
+        resolved = cmake.version if not suffix else f"{cmake.version}-{suffix}"
+
+    return ReleasePaths(version=resolved, release_dir=RELEASES_ROOT / resolved)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prepare Matrix-Control release assets under _local/releases/<version>/ "
+            "(semver tags use v prefix on git, stripped for display version)."
+        ),
+    )
+    parser.add_argument(
+        "--version",
+        help="Release display version X.Y.Z or X.Y.Z-suffix (default: CMakeLists.txt)",
+    )
+    parser.add_argument(
+        "--tag",
+        help="Git tag including v prefix (e.g. v1.0.0-rc1) — overrides --version",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing archives or RELEASE_NOTES.md",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("status", help="Show which release assets exist")
+
+    val = sub.add_parser("validate-tag", help="Validate git tag against CMakeLists.txt")
+    val.add_argument("tag", help="Git tag (e.g. v1.0.0-rc1)")
+
+    paths_cmd = sub.add_parser(
+        "print-paths",
+        help="Print expected Release artefact paths for a platform",
+    )
+    paths_cmd.add_argument("platform", choices=PLATFORM_ASSETS)
+    paths_cmd.add_argument(
+        "--artefacts-root",
+        type=Path,
+        help="Override Matrix-Control_artefacts/Release root",
+    )
+
+    pack = sub.add_parser("pack", help="Pack Release build outputs into a platform zip")
+    pack.add_argument("platform", choices=PLATFORM_ASSETS)
+    pack.add_argument(
+        "--artefacts-root",
+        type=Path,
+        help="Override Matrix-Control_artefacts/Release root",
+    )
+    pack.add_argument(
+        "--arch",
+        default="arm64",
+        help="macOS architecture label for zip filename (default: arm64)",
+    )
+
+    imp = sub.add_parser(
+        "import",
+        help="Copy an external platform archive into the release folder",
+    )
+    imp.add_argument("platform", choices=PLATFORM_ASSETS)
+    imp.add_argument("source", type=Path)
+    imp.add_argument("--arch", default="arm64")
+
+    sub.add_parser(
+        "finalize",
+        help="Create RELEASE_NOTES.md and SHA256SUMS.txt",
+    )
+    sub.add_parser("verify", help="Verify archives and checksums")
+
+    pub_ci = sub.add_parser(
+        "publish-ci",
+        help="Create GitHub release via gh (CI: tag already exists on remote)",
+    )
+    pub_ci.add_argument("-y", "--yes", action="store_true", help="Skip confirmation prompt")
+    pub_ci.add_argument("--prerelease", action="store_true", help="Force pre-release on GitHub")
+    pub_ci.add_argument(
+        "--stable",
+        action="store_true",
+        help="Force stable release (override auto prerelease detection)",
+    )
+
+    args = parser.parse_args()
+    paths = build_paths(args.version, tag=args.tag)
+
+    if args.command == "validate-tag":
+        parsed = validate_tag_against_cmake(args.tag)
+        print(f"Tag OK: {args.tag} -> {parsed.display_version}")
+    elif args.command == "status":
+        status(paths)
+    elif args.command == "print-paths":
+        artefacts = discover_artefact_paths(
+            args.platform,
+            artefacts_root=args.artefacts_root,
+        )
+        print(artefacts.vst3)
+        if artefacts.au is not None:
+            print(artefacts.au)
+        print(artefacts.standalone)
+    elif args.command == "pack":
+        pack_platform(
+            paths,
+            args.platform,
+            artefacts_root=args.artefacts_root,
+            arch=args.arch,
+            force=args.force,
+        )
+    elif args.command == "import":
+        import_archive(
+            paths,
+            args.platform,
+            args.source,
+            arch=args.arch,
+            force=args.force,
+        )
+    elif args.command == "finalize":
+        write_release_notes(paths, force=args.force)
+        write_checksums(paths)
+        print()
+        status(paths)
+    elif args.command == "verify":
+        verify_release(paths)
+    elif args.command == "publish-ci":
+        if args.prerelease and args.stable:
+            parser.error("Use only one of --prerelease or --stable")
+        tag = args.tag or f"v{paths.version}"
+        prerelease_override = None
+        if args.prerelease:
+            prerelease_override = True
+        elif args.stable:
+            prerelease_override = False
+        publish_ci(paths, tag, yes=args.yes, prerelease=prerelease_override)
+    else:
+        parser.error(f"Unknown command: {args.command}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Scripts/release/requirements-test.txt
+++ b/Scripts/release/requirements-test.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+PyYAML>=6.0

--- a/Scripts/release/templates/RELEASE_NOTES.template.md
+++ b/Scripts/release/templates/RELEASE_NOTES.template.md
@@ -1,0 +1,25 @@
+# Matrix-Control {{VERSION}}
+
+Download the zip for your platform below. Verify checksums with `SHA256SUMS.txt`.
+
+## Install
+
+### macOS
+
+1. Unzip the archive.
+2. Copy `Matrix-Control.component` to `~/Library/Audio/Plug-Ins/Components/`
+3. Copy `Matrix-Control.vst3` to `~/Library/Audio/Plug-Ins/VST3/`
+4. Optionally copy `Matrix-Control.app` to `/Applications/`
+5. If macOS reports the app as damaged, run: `xattr -cr /path/to/Matrix-Control.app`
+
+### Windows
+
+1. Unzip the archive.
+2. Copy `Matrix-Control.vst3` to `C:\Program Files\Common Files\VST3\`
+3. Run `Matrix-Control.exe` for standalone use.
+
+### Linux
+
+1. Unzip the archive.
+2. Copy `Matrix-Control.vst3` to `~/.vst3/`
+3. Run the `Matrix-Control` standalone binary.

--- a/Scripts/release/tests/test_prepare_release.py
+++ b/Scripts/release/tests/test_prepare_release.py
@@ -1,0 +1,272 @@
+"""Unit tests for Scripts/release/prepare_release.py helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PREPARE_RELEASE = PROJECT_ROOT / "Scripts" / "release" / "prepare_release.py"
+RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _load_prepare_release():
+    spec = importlib.util.spec_from_file_location("prepare_release", PREPARE_RELEASE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["prepare_release"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def prepare_release():
+    return _load_prepare_release()
+
+
+@pytest.mark.parametrize(
+    ("tag", "base", "suffix"),
+    [
+        ("v1.0.0", "1.0.0", ""),
+        ("v1.0.0-rc1", "1.0.0", "rc1"),
+        ("v0.2.0-alpha", "0.2.0", "alpha"),
+        ("v0.0.66-alpha-pre-bmad", "0.0.66", "alpha-pre-bmad"),
+    ],
+)
+def test_parse_version_from_tag(prepare_release, tag, base, suffix):
+    parsed = prepare_release.parse_version_from_tag(tag)
+    assert parsed.base_version == base
+    assert parsed.suffix == suffix
+    assert parsed.display_version == (base if not suffix else f"{base}-{suffix}")
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("v1.0.0", False),
+        ("v1.0.0-rc1", True),
+        ("v0.2.0-alpha", True),
+        ("v2.3.4-alpha.1", True),
+    ],
+)
+def test_is_prerelease_tag(prepare_release, tag, expected):
+    assert prepare_release.is_prerelease_tag(tag) is expected
+
+
+def test_validate_tag_rejects_invalid(prepare_release):
+    with pytest.raises(ValueError):
+        prepare_release.parse_version_from_tag("not-a-tag")
+
+
+def _write_cmake_lists(root: Path, *, version: str, suffix: str) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "CMakeLists.txt").write_text(
+        "\n".join(
+            [
+                f"project(Matrix-Control VERSION {version})",
+                f'set(MATRIX_CONTROL_PRERELEASE_SUFFIX "{suffix}"',
+                '    CACHE STRING "Pre-release suffix")',
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_validate_tag_against_cmake_success(prepare_release, tmp_path):
+    _write_cmake_lists(tmp_path, version="1.0.0", suffix="rc1")
+    parsed = prepare_release.validate_tag_against_cmake("v1.0.0-rc1", root=tmp_path)
+    assert parsed.display_version == "1.0.0-rc1"
+
+
+def test_validate_tag_against_cmake_version_mismatch(prepare_release, tmp_path):
+    _write_cmake_lists(tmp_path, version="1.0.0", suffix="")
+    with pytest.raises(SystemExit, match="does not match"):
+        prepare_release.validate_tag_against_cmake("v2.0.0", root=tmp_path)
+
+
+def test_validate_tag_against_cmake_suffix_mismatch(prepare_release, tmp_path):
+    _write_cmake_lists(tmp_path, version="1.0.0", suffix="alpha")
+    with pytest.raises(SystemExit, match="suffix"):
+        prepare_release.validate_tag_against_cmake("v1.0.0-rc1", root=tmp_path)
+
+
+def test_verify_release_requires_all_platform_archives(prepare_release, tmp_path, capsys):
+    release_dir = tmp_path / "1.0.0"
+    release_dir.mkdir()
+    paths = prepare_release.ReleasePaths(version="1.0.0", release_dir=release_dir)
+    linux_zip = release_dir / "Matrix-Control-v1.0.0-Linux.zip"
+    linux_zip.write_bytes(b"zip")
+    (release_dir / "RELEASE_NOTES.md").write_text("# Notes", encoding="utf-8")
+    digest = hashlib.sha256(linux_zip.read_bytes()).hexdigest()
+    (release_dir / "SHA256SUMS.txt").write_text(
+        f"{digest}  {linux_zip.name}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        prepare_release.verify_release(paths)
+
+    captured = capsys.readouterr()
+    assert "Missing required platform archives" in captured.out
+
+
+def test_discover_artefact_paths_rejects_empty_bundle(prepare_release, tmp_path):
+    root = tmp_path / "artefacts"
+    vst3 = root / "VST3" / "Matrix-Control.vst3"
+    standalone = root / "Standalone" / "Matrix-Control"
+    vst3.mkdir(parents=True)
+    standalone.mkdir(parents=True)
+
+    with pytest.raises(SystemExit, match="empty bundle"):
+        prepare_release.discover_artefact_paths("linux", artefacts_root=root)
+
+
+def test_publish_ci_reuploads_when_release_exists(prepare_release, tmp_path):
+    release_dir = tmp_path / "1.0.0-rc1"
+    release_dir.mkdir()
+    paths = prepare_release.ReleasePaths(version="1.0.0-rc1", release_dir=release_dir)
+
+    for suffix in ("macOS-arm64", "Windows", "Linux"):
+        (release_dir / f"Matrix-Control-v1.0.0-rc1-{suffix}.zip").write_bytes(b"zip")
+
+    (release_dir / "RELEASE_NOTES.md").write_text("# Notes", encoding="utf-8")
+    (release_dir / "SHA256SUMS.txt").write_text("deadbeef  fake\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, cwd=None, check=True):
+        calls.append([str(part) for part in cmd])
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch.object(prepare_release, "verify_release"), patch.object(
+        prepare_release, "_gh_release_exists", return_value=True
+    ), patch.object(prepare_release, "_run", side_effect=fake_run):
+        prepare_release.publish_ci(paths, "v1.0.0-rc1", yes=True)
+
+    joined = [" ".join(cmd) for cmd in calls]
+    assert not any("gh release create" in line for line in joined)
+    assert any("gh release upload" in line for line in joined)
+    assert any("--notes-file" in line for line in joined)
+    assert not any(cmd[0] == "git" for cmd in calls)
+
+
+def test_publish_ci_invokes_gh_not_git(prepare_release, tmp_path):
+    release_dir = tmp_path / "1.0.0-rc1"
+    release_dir.mkdir()
+    paths = prepare_release.ReleasePaths(version="1.0.0-rc1", release_dir=release_dir)
+
+    for suffix in ("macOS-arm64", "Windows", "Linux"):
+        (release_dir / f"Matrix-Control-v1.0.0-rc1-{suffix}.zip").write_bytes(b"zip")
+
+    (release_dir / "RELEASE_NOTES.md").write_text("# Notes", encoding="utf-8")
+    (release_dir / "SHA256SUMS.txt").write_text("deadbeef  fake\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, cwd=None, check=True):
+        calls.append([str(part) for part in cmd])
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch.object(prepare_release, "verify_release"), patch.object(
+        prepare_release, "_gh_release_exists", return_value=False
+    ), patch.object(prepare_release, "_run", side_effect=fake_run):
+        prepare_release.publish_ci(paths, "v1.0.0-rc1", yes=True)
+
+    joined = [" ".join(cmd) for cmd in calls]
+    assert any("gh release create" in line for line in joined)
+    assert any("--prerelease" in line for line in joined)
+    assert not any(cmd[0] == "git" for cmd in calls)
+
+
+def test_publish_ci_stable_release_omits_prerelease_flag(prepare_release, tmp_path):
+    release_dir = tmp_path / "1.0.0"
+    release_dir.mkdir()
+    paths = prepare_release.ReleasePaths(version="1.0.0", release_dir=release_dir)
+
+    for suffix in ("macOS-arm64", "Windows", "Linux"):
+        (release_dir / f"Matrix-Control-v1.0.0-{suffix}.zip").write_bytes(b"zip")
+    (release_dir / "RELEASE_NOTES.md").write_text("# Notes", encoding="utf-8")
+    (release_dir / "SHA256SUMS.txt").write_text("deadbeef  fake\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *, cwd=None, check=True):
+        calls.append([str(part) for part in cmd])
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch.object(prepare_release, "verify_release"), patch.object(
+        prepare_release, "_gh_release_exists", return_value=False
+    ), patch.object(prepare_release, "_run", side_effect=fake_run):
+        prepare_release.publish_ci(paths, "v1.0.0", yes=True)
+
+    gh_cmd = next(cmd for cmd in calls if cmd[0:3] == ["gh", "release", "create"])
+    assert "--prerelease" not in gh_cmd
+
+
+def test_build_gh_release_create_cmd_no_git(prepare_release, tmp_path):
+    release_dir = tmp_path / "1.0.0"
+    release_dir.mkdir()
+    paths = prepare_release.ReleasePaths(version="1.0.0", release_dir=release_dir)
+    (release_dir / "Matrix-Control-v1.0.0-Linux.zip").write_bytes(b"z")
+    (release_dir / "RELEASE_NOTES.md").write_text("# Notes", encoding="utf-8")
+
+    cmd = prepare_release.build_gh_release_create_cmd(paths, "v1.0.0", prerelease=False)
+    assert cmd[0:3] == ["gh", "release", "create"]
+    assert "v1.0.0" in cmd
+    assert "git" not in cmd
+
+
+def test_release_workflow_structure():
+    workflow_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    workflow = yaml.safe_load(workflow_text)
+    triggers = workflow.get("on") or workflow.get(True) or {}
+
+    assert "workflow_dispatch" not in triggers
+    assert "pull_request" not in triggers
+    assert "push" in triggers
+    assert "tags" in triggers["push"]
+    assert "v*.*.*" in triggers["push"]["tags"]
+    assert "branches" not in triggers["push"]
+    assert workflow["env"]["JUCE_VERSION"] == "8.0.12"
+    assert workflow["permissions"]["contents"] == "write"
+    assert workflow["concurrency"]["cancel-in-progress"] is False
+
+    jobs = workflow["jobs"]
+    assert set(jobs) == {"validate-tag", "build", "publish"}
+    assert jobs["build"]["needs"] in (["validate-tag"], "validate-tag")
+    assert jobs["publish"]["needs"] in (["validate-tag", "build"], ["build", "validate-tag"])
+    assert jobs["validate-tag"]["timeout-minutes"] == 10
+    assert jobs["build"]["timeout-minutes"] == 90
+    assert jobs["publish"]["timeout-minutes"] == 20
+
+    build_yaml = yaml.dump(jobs["build"])
+    assert "macos-release-arm64" in build_yaml
+    assert "windows-release" in build_yaml
+    assert "linux-release" in build_yaml
+    assert "prepare_release.py" in build_yaml
+    assert "pack" in build_yaml
+    assert "macos-latest" in build_yaml
+    assert "windows-latest" in build_yaml
+    assert "ubuntu-latest" in build_yaml
+    assert "MATRIX_BUILD_TESTS=ON" in workflow_text
+    assert "USER_COPY_TO_SYSTEM_FOLDERS=OFF" in workflow_text
+    assert "USER_COPY_TO_ARTEFACTS_DIR=OFF" in workflow_text
+    assert "fail-fast: false" in build_yaml or "fail-fast: false" in build_yaml.replace("'", '"')
+    assert "notarytool submit" in workflow_text
+    assert "codesign --force" in workflow_text
+
+    publish_yaml = yaml.dump(jobs["publish"])
+    assert "prepare_release.py" in publish_yaml
+    assert "finalize" in publish_yaml
+    assert "publish-ci --yes" in publish_yaml
+
+    validate_yaml = yaml.dump(jobs["validate-tag"])
+    assert "validate-tag" in validate_yaml
+    assert "prepare_release.py" in validate_yaml

--- a/_bmad-output/implementation-artifacts/11-1-ci-multi-platform-build-and-tests.md
+++ b/_bmad-output/implementation-artifacts/11-1-ci-multi-platform-build-and-tests.md
@@ -12,7 +12,7 @@ baseline_workflow: none
 
 # Story 11.1: CI Multi-Platform (build + unit tests matrix)
 
-Status: review
+Status: done
 
 <!-- Epic 11 — CI & Release Infrastructure. Sprint Change Proposal 2026-07-11. -->
 
@@ -41,8 +41,8 @@ So that cross-platform compile regressions and logic failures are caught before 
 | Concern | CI approach |
 |---------|-------------|
 | JUCE | Checkout tag `8.0.12` → `JUCE_DIR` env |
-| Artefact copy | `-DCOPY_TO_SYSTEM_FOLDERS=OFF -DCOPY_TO_ARTEFACTS_DIR=OFF` |
-| Windows VS | GitHub `windows-latest` → likely VS 2022 preset (`windows-debug-vs2022`) |
+| Artefact copy | `-DUSER_COPY_TO_SYSTEM_FOLDERS=OFF -DUSER_COPY_TO_ARTEFACTS_DIR=OFF` (propagates to `COPY_TO_*` via CMake) |
+| Windows VS | GitHub `windows-latest` → `windows-debug` preset (VS 2026; `windows-debug-vs2022` retained for local legacy) |
 | macOS | `macos-latest` = Apple Silicon → `macos-debug-arm64` |
 | Linux | apt deps for JUCE (document in workflow + CONTRIBUTING) |
 | Tests | Build + run `Matrix-Control_Tests` — no `--unit-tests` plugin flag |
@@ -100,6 +100,27 @@ So that cross-platform compile regressions and logic failures are caught before 
 - [x] Fix `README.md` CI status line
 - [x] Optional: add CI preset overrides or documented `-D` flags
 
+### Review Findings
+
+- [x] [Review][Decision] **Preset Windows : VS 2026 vs VS 2022** — Résolu : garder `windows-debug` (VS 2026) ; mettre à jour spec/constraints pour refléter le choix documenté dans le workflow.
+- [x] [Review][Decision] **Seams de test dans le code Core de production** — Résolu : garder tel quel (seams commentés, simplicité acceptable).
+- [x] [Review][Decision] **Tests debounce : flush synchrone vs attente timer** — Résolu : accepter le compromis CI (flush sync, pas de restauration wall-clock).
+
+- [x] [Review][Patch] **Build step Windows sans shell explicite** [`.github/workflows/build-and-test.yml:100`]
+- [x] [Review][Patch] **Pas de vérification d'existence du binaire de test** [`.github/workflows/build-and-test.yml:106`]
+- [x] [Review][Patch] **Pas de timeout sur le job CI** [`.github/workflows/build-and-test.yml:26`]
+- [x] [Review][Patch] **File List story incomplète** [`11-1-ci-multi-platform-build-and-tests.md:133`]
+- [x] [Review][Patch] **Spec constraints : preset Windows + noms flags COPY** [`11-1-ci-multi-platform-build-and-tests.md:512`]
+- [x] [Review][Patch] **Completion notes : preuve CI PR #20 absente** [`11-1-ci-multi-platform-build-and-tests.md:131`]
+- [x] [Review][Patch] **Lien TOC CI pointe vers claude.ai** [`CONTRIBUTING.md:13`]
+
+- [x] [Review][Defer] **Chemins test_binary hard-codés par OS** [`.github/workflows/build-and-test.yml:35-43`] — deferred, pre-existing fragility acceptable while paths stable
+- [x] [Review][Defer] **COPY_* CACHE FORCE vs cache stale local** [`CMakeLists.txt:132-133`] — deferred, CI fresh checkout mitigates
+- [x] [Review][Defer] **TOC CONTRIBUTING entier en URLs claude.ai** [`CONTRIBUTING.md:9-17`] — deferred, pre-existing
+- [x] [Review][Defer] **Thread::sleep(50) dans MidiManagerTests** [`Tests/Unit/MidiManagerTests.cpp:205`] — deferred, pre-existing
+- [x] [Review][Defer] **Chemins Dropbox dans CMakeUserPresets** [`CMakeUserPresets.json`] — deferred, copy OFF en CI
+- [x] [Review][Defer] **Tests MIDI skip silencieux sans device** [`Tests/Unit/MidiManagerTests.cpp:362`] — deferred, conforme AC3 headless
+
 ## Dev Notes
 
 - **Recent fixes to protect:** `ApvtsLogger` Linux cast, router stub linkage, embedded Orbitron font.
@@ -128,7 +149,8 @@ So that cross-platform compile regressions and logic failures are caught before 
 - ✅ `CMakeLists.txt` — USER copy flags respect `-D` overrides; `PluginDescriptorsMasterEdit.cpp` linked into test target.
 - ✅ `CONTRIBUTING.md` — Continuous Integration section with matrix table and local reproduction commands.
 - ✅ `README.md` — CI status updated to ✅ (multi-platform build + tests on push/PR to `main`).
-- ✅ macOS leg verified locally: plugin + `Matrix-Control_Tests` build and run (exit 0). Windows/Linux legs use same workflow pattern; first GHA run on merge to `main` confirms cross-platform green.
+- ✅ macOS leg verified locally: plugin + `Matrix-Control_Tests` build and run (exit 0).
+- ✅ PR #20 CI (2026-07-11): all three matrix legs green on `ubuntu-latest`, `windows-latest`, and `macos-latest` before merge to `main`.
 
 ## File List
 
@@ -136,11 +158,23 @@ So that cross-platform compile regressions and logic failures are caught before 
 - `CMakeLists.txt` (modified)
 - `CONTRIBUTING.md` (modified)
 - `README.md` (modified)
+- `Source/Core/Actions/MutatorActionHandler.h` (modified — test seam)
+- `Source/Core/Util/ComboboxPatchSendDebouncer.cpp` (modified — test seam)
+- `Source/Core/Util/ComboboxPatchSendDebouncer.h` (modified — test seam)
+- `Tests/TestMain.cpp` (modified — GUI initialiser for headless CI)
+- `Tests/Unit/ComboboxPatchSendDebouncerTests.cpp` (modified — sync flush)
+- `Tests/Unit/MidiManagerTests.cpp` (modified — skip without MIDI device)
+- `Tests/Unit/MutatorActionHandlerTests.cpp` (modified — sync flush)
 - `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+- `_bmad-output/planning-artifacts/epics.md` (modified)
+- `_bmad-output/planning-artifacts/prds/prd-matrix-control-2026-05-25/.decision-log.md` (modified)
+- `_bmad-output/planning-artifacts/prds/prd-matrix-control-2026-05-25/prd.md` (modified)
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-07-11-ci-infrastructure.md` (added)
 
 ## Change Log
 
 - 2026-07-11 — Story 11.1 implemented: GitHub Actions 3-OS build+test matrix, CI copy-flag fix, test target link fix, CONTRIBUTING/README CI docs.
+- 2026-07-11 — Code review: workflow hardening (timeout, bash shell, test binary preflight), story traceability/doc fixes, CONTRIBUTING CI TOC anchor.
 
 ## References
 

--- a/_bmad-output/implementation-artifacts/11-2-cd-release-pipeline.md
+++ b/_bmad-output/implementation-artifacts/11-2-cd-release-pipeline.md
@@ -1,0 +1,350 @@
+---
+organization: Ten Square Software
+project: Matrix-Control
+title: Story 11.2 — CD Release Pipeline
+author: BMad Agent
+status: review
+epic: 11
+story: 2
+story_key: 11-2-cd-release-pipeline
+depends_on: [11-1]
+blocks: []
+implementation_order: 2
+correct_course_date: 2026-07-11
+baseline_commit: 0eaee973
+baseline_workflow: .github/workflows/build-and-test.yml
+sources:
+  - planning-artifacts/epics.md
+  - planning-artifacts/sprint-change-proposal-2026-07-11-ci-infrastructure.md
+  - implementation-artifacts/11-1-ci-multi-platform-build-and-tests.md
+  - Luthier 10-2-cd-release-pipeline (external reference)
+created: 2026-07-11
+updated: 2026-07-11
+---
+
+# Story 11.2: CD Release Pipeline
+
+Status: done
+
+<!-- Epic 11 — CI & Release Infrastructure. Originally deferred pre-v1.0.0; story created 2026-07-11 for implementation planning. -->
+
+## Story
+
+As a maintainer,
+I want pushing a semver git tag to trigger multi-OS **Release** plugin builds and a GitHub Release with downloadable artefacts,
+So that v1.0.0 distribution does not require manual per-OS packaging, signing, and upload.
+
+## Context
+
+**Correct Course 2026-07-11:** Story **11.1** delivers Debug build + unit tests on push/PR. Distribution is still **manual**: local Release presets, personal `ARTEFACTS_DIR_*` paths in `CMakeUserPresets.json`, and ad-hoc copy to Dropbox.
+
+**Target workflow:** bump `project(Matrix-Control VERSION …)` in `CMakeLists.txt` → commit → `git tag vX.Y.Z[-suffix]` → `git push origin vX.Y.Z[-suffix]` → CI builds Release binaries, packages per-OS zips, signs/notarizes macOS, and publishes a GitHub Release.
+
+**Luthier reference (Story 10.2):** Tag-triggered `.github/workflows/release.yml`; packaging logic in `publish/prepare-release.py`; **`publish-ci`** subcommand that calls `gh release create` only (tag already exists — no tag recreation, no clean-tree check). **Adapt for JUCE:** Matrix-Control has no `publish/` tree yet; plugin artefacts are AU/VST3/Standalone bundles, not PyInstaller zips; **macOS codesign + notarization are in scope** (Luthier explicitly deferred signing).
+
+**Originally deferred because:** AU/VST3 codesign, macOS notarization, and v1 distribution packaging are substantially harder than Luthier's Python app. Story is now ready-for-dev — **implementation may still wait until v1.0.0 release planning** if Apple Developer credentials or Epic U-10 release gate are not satisfied.
+
+**Planning references:**
+- `_bmad-output/planning-artifacts/sprint-change-proposal-2026-07-11-ci-infrastructure.md` §4.3
+- `_bmad-output/planning-artifacts/epics.md` — Epic 11 Story 11.2
+- Luthier: `10-2-cd-release-pipeline.md` (GitHub: tensquaresoftware/luthier)
+- Pamplejuce / Melatonin CI signing patterns (external — see Latest Tech Information)
+
+### Release constraints (Matrix-Control specific)
+
+| Concern | CD approach |
+|---------|-------------|
+| Version SSOT | `project(Matrix-Control VERSION X.Y.Z)` in `CMakeLists.txt` → `MATRIX_CONTROL_PROJECT_VERSION` compile define → `PluginVersion::getVersionString()` |
+| Pre-release suffix | `MATRIX_CONTROL_PRERELEASE_SUFFIX` CACHE (default `"alpha"`) — **must be empty string for stable v1.0.0**; for `v1.0.0-rc1` set suffix to `rc1` or derive from tag |
+| Tag convention | Existing repo tags use **`v` prefix** (`v0.0.66-alpha-pre-bmad`) — **keep `v` prefix**; validate tag (strip `v`) matches `PROJECT_VERSION` + optional suffix |
+| Build type | **Release** presets only (`macos-release-*`, `windows-release`, `linux-release`) — not Debug |
+| Formats per OS | macOS: AU + VST3 + Standalone; Windows/Linux: VST3 + Standalone (AU stripped by CMake on non-Apple) |
+| macOS arch (CI) | `macos-latest` = Apple Silicon → default **`macos-release-arm64`**; document optional **`macos-release-universal`** if v1 ships fat binary |
+| Copy side effects | `-DUSER_COPY_TO_SYSTEM_FOLDERS=OFF -DUSER_COPY_TO_ARTEFACTS_DIR=OFF` (same as CI 11.1) |
+| Tests gate | Run `Matrix-Control_Tests` on each matrix leg **before** packaging (Release build) |
+| Signing | macOS: Developer ID Application + `notarytool` (**required for public macOS distribution**); Windows: **optional v1** — document unsigned fallback or defer Azure Trusted Signing |
+| Release binary hygiene | Epic U Story U-10 (`TestComponent` excluded from Release) is the **v1.0.0 release gate** — CD must build Release config; verify sandbox not in Release binary before first public tag |
+
+## Acceptance Criteria
+
+### AC1 — Tag trigger only
+
+**Given** a semver tag push matching `v*.*.*` (e.g. `v1.0.0`, `v1.0.0-rc1`, `v0.2.0-alpha`)  
+**When** GitHub Actions runs  
+**Then** `.github/workflows/release.yml` triggers on `push: tags:` only — **not** on push/PR to `main`  
+**And** **`workflow_dispatch` is out of scope** (match Luthier 10.2 — first validation is a real tag push)
+
+### AC2 — Release build matrix
+
+**Given** the release workflow  
+**When** build jobs run  
+**Then** jobs execute on `macos-latest`, `windows-latest`, and `ubuntu-latest`  
+**And** each leg checks out JUCE **8.0.12**, configures with **Release** preset, `MATRIX_BUILD_TESTS=ON`, copy flags OFF  
+**And** builds `Matrix-Control` (all format targets) + `Matrix-Control_Tests`, runs tests, then packages artefacts  
+**And** `fail-fast: false` and generous `timeout-minutes` (Release + signing legs exceed Debug CI)
+
+### AC3 — Per-OS artefact packages
+
+**Given** a successful Release build on each OS  
+**When** packaging runs  
+**Then** each leg produces a versioned zip uploaded as a workflow artifact:
+
+| OS | Zip contents (minimum) |
+|----|------------------------|
+| macOS | `Matrix-Control.vst3`, `Matrix-Control.component`, `Matrix-Control.app` |
+| Windows | `Matrix-Control.vst3/`, `Matrix-Control.exe` |
+| Linux | `Matrix-Control.vst3/`, `Matrix-Control` standalone binary |
+
+**And** zip names follow a consistent pattern, e.g. `Matrix-Control-v{VERSION}-macOS-{arch}.zip`  
+**And** packaging logic lives in **`Scripts/release/`** (or `publish/`) — **not** duplicated as raw shell in YAML beyond thin wrappers
+
+### AC4 — macOS codesign and notarization
+
+**Given** macOS build artefacts and repository secrets configured  
+**When** the macOS leg completes build  
+**Then** AU, VST3, and Standalone bundles are signed with **Developer ID Application** (`--options=runtime --timestamp`)  
+**And** signed bundles are submitted via **`xcrun notarytool submit --wait`** and stapled (or documented zip-notarize flow)  
+**And** workflow **fails clearly** if signing secrets are missing (no silent skip of notarization on a stable release tag)  
+**And** required secrets are documented in `CONTRIBUTING.md` (names only — never values)
+
+### AC5 — Publish job and GitHub Release
+
+**Given** all three build jobs succeed  
+**When** the publish job runs  
+**Then** it downloads per-OS zip artifacts  
+**And** generates `SHA256SUMS.txt` (and optionally `RELEASE_NOTES.md` from tag message or template)  
+**And** runs **`publish-ci`** (script subcommand) to invoke `gh release create` with all assets attached  
+**And** workflow has `permissions: contents: write`
+
+### AC6 — publish-ci (no tag recreation)
+
+**Given** the tag already exists on the remote when the workflow runs  
+**When** `publish-ci` executes  
+**Then** it does **not** create, move, or push a git tag  
+**And** it does **not** require a clean working tree  
+**And** it invokes `gh release create` (idempotent or fail-with-clear-message on re-run — see Luthier 10.2 review patch)
+
+### AC7 — Prerelease detection
+
+**Given** tag `v1.0.0-rc1` (or any `vX.Y.Z-<suffix>` where suffix is not `alpha`/`beta` alone — see Dev Notes)  
+**When** GitHub Release is created  
+**Then** it is marked **`--prerelease`**  
+**Given** tag `v1.0.0` with empty `MATRIX_CONTROL_PRERELEASE_SUFFIX`  
+**Then** stable (non-prerelease) release
+
+### AC8 — Version/tag alignment
+
+**Given** the tagged commit  
+**When** `validate-tag` job runs (before or as first step of matrix)  
+**Then** semver parsed from tag (strip leading `v`) matches `project(Matrix-Control VERSION …)` in `CMakeLists.txt` at that commit  
+**And** pre-release suffix in tag aligns with `MATRIX_CONTROL_PRERELEASE_SUFFIX` when non-empty  
+**And** mismatch **fails the workflow** before expensive builds
+
+### AC9 — Documentation
+
+**Given** the workflow is merged  
+**When** a maintainer reads **`CONTRIBUTING.md`**  
+**Then** a **Releasing** section documents: version bump, suffix clearing, tag format, required secrets, RC → smoke test → stable tag flow  
+**And** **`README.md`** mentions tag-triggered releases (link to Releases page)  
+**And** manual local release steps remain documented as fallback
+
+### AC10 — Tests
+
+**Given** story completion  
+**Then** unit tests cover: prerelease detection helper, tag/version parsing, `publish-ci` command assembly (no git tag creation)  
+**And** workflow YAML structure is validated in tests (parse jobs, required steps — match Luthier 10.2 test pattern)  
+**And** existing `Matrix-Control_Tests` still pass in CI Debug workflow (11.1 regression)
+
+## Tasks / Subtasks
+
+- [x] Create `Scripts/release/prepare_release.py` (or `publish/prepare-release.py`) — Luthier 10.2 port (AC: 3, 5, 6, 7)
+  - [x] `pack` — collect JUCE artefact paths into versioned zip per OS
+  - [x] `finalize` — merge artifacts, write `SHA256SUMS.txt`, optional release notes
+  - [x] `publish-ci` — `gh release create` only; `--yes` for CI
+  - [x] `is_prerelease_tag()` / `parse_version_from_tag()` helpers
+  - [x] Shared helper extracted from any future local `publish` flow (avoid YAML duplication)
+
+- [x] Create `.github/workflows/release.yml` (AC: 1, 2, 5, 8)
+  - [x] `on.push.tags: ['v*.*.*']` — document that filter is broad; `validate-tag` job enforces semver
+  - [x] `permissions: contents: write`; `cancel-in-progress: false`
+  - [x] `validate-tag` job: regex + `CMakeLists.txt` version extract
+  - [x] Matrix build: JUCE cache, Linux apt deps (reuse 11.1 list), Release configure/build/test/package
+  - [x] macOS job: import certs → keychain → codesign → notarize → staple → zip
+  - [x] `actions/upload-artifact` per platform; publish job: download → finalize → publish-ci
+
+- [x] CMake / version hygiene (AC: 8)
+  - [x] Document Release configure flag: `-DMATRIX_CONTROL_PRERELEASE_SUFFIX=""` for stable releases
+  - [x] Optional: CI sets suffix from tag via `-D` override (avoid manual CMake edit for RC tags)
+
+- [x] Repository secrets checklist (AC: 4, 9) — Guillaume configures in GitHub Settings
+  - [x] `DEV_ID_APP_CERT`, `DEV_ID_APP_PASSWORD`, `DEVELOPER_ID_APPLICATION`
+  - [x] `NOTARIZATION_USERNAME`, `NOTARIZATION_PASSWORD` (app-specific), `APPLE_TEAM_ID`
+  - [x] (Optional v1) Windows Authenticode secrets
+
+- [x] Update `CONTRIBUTING.md` — Releasing section (AC: 9)
+- [x] Update `README.md` — release badge or Releases link (AC: 9)
+- [x] Add tests under `Tests/` or `Scripts/release/tests/` (AC: 10)
+- [x] Dry-run validation: push **`v0.2.0-alpha`** test tag (or RC) after secrets configured; confirm GitHub Release assets — **deferred to maintainer post-merge** (AC1 forbids `workflow_dispatch`; requires GitHub secrets + real tag push)
+
+### Review Findings
+
+- [x] [Review][Patch] Ajouter les tests `Scripts/release/tests/` dans `build-and-test.yml` (décision #1 : exécution CI) [.github/workflows/build-and-test.yml]
+- [x] [Review][Patch] Notarisation macOS : staple sur les bundles originaux après soumission d'un meta-zip [.github/workflows/release.yml:237-245]
+- [x] [Review][Patch] Aucun test unitaire pour `validate_tag_against_cmake` (alignement tag ↔ CMakeLists) [Scripts/release/tests/test_prepare_release.py]
+- [x] [Review][Patch] Pas de test pour le chemin idempotent `publish-ci` quand la release GitHub existe déjà [Scripts/release/tests/test_prepare_release.py]
+- [x] [Review][Patch] `verify_release` n'exige pas les 3 archives plateforme avant publication [Scripts/release/prepare_release.py:295]
+- [x] [Review][Patch] Re-publication : notes de release non mises à jour quand la release GitHub existe déjà [Scripts/release/prepare_release.py:402]
+- [x] [Review][Patch] Bundles vides non détectés dans `discover_artefact_paths` [Scripts/release/prepare_release.py:171]
+- [x] [Review][Patch] Tests YAML workflow incomplets (AC10 : JUCE pin, copy flags, timeouts, étapes sign/notarize) [Scripts/release/tests/test_prepare_release.py]
+- [x] [Review][Patch] Ajouter `__pycache__/` au `.gitignore` pour éviter commit accidentel des caches Python [/.gitignore]
+
+- [x] [Review][Defer] Dry-run E2E (push tag réel + assets GitHub Release) — deferred, post-merge maintainer (déjà documenté story L187)
+- [x] [Review][Defer] Windows Authenticode non signé pour v1 — deferred, documenté CONTRIBUTING (choix spec)
+- [x] [Review][Defer] macOS arm64-only en CI (pas universal) — deferred, décision spec / Dev Notes
+- [x] [Review][Defer] Pins pytest/PyYAML sans borne supérieure — deferred, dette mineure reproductibilité
+
+## Dev Notes
+
+### JUCE Release artefact paths (reference — verify after configure)
+
+Paths follow JUCE CMake layout under preset `binaryDir`:
+
+| OS | Preset (CI default) | VST3 | AU | Standalone |
+|----|---------------------|------|-----|------------|
+| macOS | `macos-release-arm64` | `Builds/macOS/ARM/Release/Matrix-Control_artefacts/Release/VST3/Matrix-Control.vst3` | `…/AU/Matrix-Control.component` | `…/Standalone/Matrix-Control.app` |
+| Windows | `windows-release` | `Builds/Windows/Matrix-Control_artefacts/Release/VST3/Matrix-Control.vst3` | — | `…/Standalone/Matrix-Control.exe` |
+| Linux | `linux-release` | `Builds/Linux/Release/Matrix-Control_artefacts/Release/VST3/Matrix-Control.vst3` | — | `…/Standalone/Matrix-Control` |
+
+**Do not hard-code** without `test -f` preflight (11.1 review lesson). Prefer discovering paths from CMake output or a small `--print-paths` script flag.
+
+### Tag vs Luthier difference
+
+| | Luthier 10.2 | Matrix-Control 11.2 |
+|---|-------------|---------------------|
+| Tag format | `1.0.0-rc1` (no `v`) | `v1.0.0-rc1` (**keep existing convention**) |
+| Version file | `app/version.py` | `CMakeLists.txt` `project(… VERSION …)` |
+| Artefacts | Single PyInstaller zip / OS | AU + VST3 + Standalone bundles / OS |
+| Signing | Out of scope | **macOS in scope** |
+| Build type | N/A (Python) | CMake **Release** |
+
+### Prerelease policy
+
+- Tags like `v0.2.0-alpha` match historical alpha releases — treat as **prerelease** on GitHub.
+- Stable public v1: tag `v1.0.0` + `MATRIX_CONTROL_PRERELEASE_SUFFIX=""` at configure time.
+- Implement `is_prerelease_tag()` conservatively: any tag with suffix after `X.Y.Z` → prerelease; bare `vX.Y.Z` → stable only if suffix cache empty.
+
+### CI workflow relationship
+
+| Workflow | Trigger | Build | Purpose |
+|----------|---------|-------|---------|
+| `build-and-test.yml` (11.1) | push/PR → `main` | Debug + tests | Merge gate |
+| `release.yml` (11.2) | tag `v*.*.*` | Release + tests + pack + sign | Distribution |
+
+Do **not** merge release workflow into 11.1 — separation keeps PR CI fast (Story 11.3 optimizes 11.1 only).
+
+### Architecture compliance
+
+- **No Core/GUI code changes required** for basic CD — infrastructure-only story.
+- **Do not** commit signing certificates or notarization passwords.
+- **Do not** enable `COPY_TO_ARTEFACTS_DIR` with personal Dropbox paths in CI.
+- Version displayed in About modal (`PluginVersion.cpp`) must match released tag — already driven by CMake defines.
+
+### Previous story intelligence (11.1)
+
+- Reuse JUCE 8.0.12 cache pattern from `build-and-test.yml`.
+- Reuse Linux apt package list verbatim.
+- Windows: `windows-release` preset (VS 2026) — same generator family as Debug CI.
+- `fail-fast: false` on matrix; job `timeout-minutes` mandatory (Release legs are slower).
+- Explicit `shell: bash` on Windows for configure/build where applicable.
+- Test binary preflight: `test -f` before execute.
+- 11.1 explicitly scoped **out** release workflow — do not regress Debug CI when adding `release.yml`.
+
+### Git intelligence (recent)
+
+- `0eaee97` — Story 7-5 review fixes (unrelated to CD; no conflict).
+- `ab0a263` / PR #20 — Story 11.1 merged: `.github/workflows/build-and-test.yml`, CMake copy-flag CACHE fix.
+- First CD implementation should branch from current `main` with 11.1 CI green.
+
+### Latest tech information
+
+- **macOS signing in CI:** Import `.p12` into ephemeral keychain; `codesign --force -s "$DEVELOPER_ID_APPLICATION" --options=runtime --timestamp` on each bundle ([Melatonin guide](https://melatonin.dev/blog/how-to-code-sign-and-notarize-macos-audio-plugins-in-ci/)).
+- **Notarization:** Prefer `xcrun notarytool submit` with app-specific password + `--wait`; staple with `xcrun stapler staple`. Zip bundles before submit if using zip workflow.
+- **Reference implementation:** [Pamplejuce](https://github.com/sudara/pamplejuce) GitHub Actions + `sudara/basic-macos- codesign` action patterns (adapt to Matrix-Control secret names).
+- **Windows v1:** Unsigned VST3/Standalone is common for open-source MIT plugins; Authenticode via Azure Trusted Signing is optional follow-up — document in CONTRIBUTING if deferred.
+- **JUCE 8.0.12:** Pin same tag as 11.1; no JUCE upgrade in this story.
+
+### Project context reference
+
+- Tags: annotated, `v0.0.xx-alpha[-suffix]` format (`project-context.md` § Git & Release Conventions).
+- Distribution v1: **free MIT** + GitHub Releases (`brief` addendum § Distribution).
+- Target release: Christmas 2026 aspirational — CD pipeline enables RC tags before v1.0.0.
+
+### Out of scope
+
+- Story **11.3** CI build-time optimizations (Debug PR workflow only)
+- Linux VST3/Standalone **format enablement** in README (still 🔜) — CD can still build Linux targets if CMake produces them
+- Windows `.msi` / macOS `.pkg` **installers** (raw zip sufficient for v1 — match brief open-source distribution)
+- **`workflow_dispatch`** manual releases
+- App Store / AAX / CLAP
+- Automated hardware smoke tests post-release
+
+### Open decisions (maintainer — resolve during dev-story)
+
+1. **macOS universal vs arm64-only** for public v1 download — CI default arm64; universal requires `macos-release-universal` preset and longer build.
+2. **Windows signing** — required for v1 or defer with documented unsigned build?
+3. **First validation tag** — `v0.2.0-alpha` smoke vs wait for `v1.0.0-rc1` after Epic U-10.
+4. **Release notes source** — git tag annotation vs `CHANGELOG.md` vs template file.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Composer (Cursor)
+
+### Debug Log References
+
+- Release script tests: 19 passed (`python3 -m pytest Scripts/release/tests/ -q`)
+- Local `Matrix-Control_Tests` regression: passed on macOS Debug binary
+- `validate-tag v0.1.1-alpha` OK against current `CMakeLists.txt` (VERSION 0.1.1, suffix alpha)
+
+### Completion Notes List
+
+- ✅ AC1–10 implemented: tag-only `release.yml`, 3-OS Release matrix + tests, macOS sign/notarize (fail if secrets missing), `Scripts/release/prepare_release.py` with pack/finalize/publish-ci, CONTRIBUTING Releasing section, README Releases link.
+- ✅ CI passes `-DMATRIX_CONTROL_PRERELEASE_SUFFIX` from tag suffix at configure time (AC8 hygiene).
+- ✅ Windows signing deferred for v1 — documented unsigned fallback in CONTRIBUTING.
+- ✅ macOS CI default: arm64-only (`macos-release-arm64`); universal documented as optional.
+- ⏳ E2E dry-run (push test tag + confirm GitHub Release assets) pending maintainer after GitHub secrets configured — procedure in CONTRIBUTING § Releasing.
+
+- ✅ Code review 2026-07-11: 9 patches applied (notarization per-bundle, verify_release hardening, CI release-script tests, expanded unit tests, .gitignore).
+
+### File List
+
+- `.github/workflows/release.yml` (added)
+- `.github/workflows/build-and-test.yml` (modified — release-script-tests job)
+- `Scripts/release/prepare_release.py` (added)
+- `Scripts/release/templates/RELEASE_NOTES.template.md` (added)
+- `Scripts/release/tests/test_prepare_release.py` (added)
+- `Scripts/release/requirements-test.txt` (added)
+- `CONTRIBUTING.md` (modified)
+- `README.md` (modified)
+- `.gitignore` (modified)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+
+## References
+
+- [Source: `_bmad-output/planning-artifacts/epics.md` — Epic 11 Story 11.2]
+- [Source: `_bmad-output/planning-artifacts/sprint-change-proposal-2026-07-11-ci-infrastructure.md` §4.3]
+- [Source: `_bmad-output/implementation-artifacts/11-1-ci-multi-platform-build-and-tests.md`]
+- [Source: `.github/workflows/build-and-test.yml`]
+- [Source: `CMakeLists.txt` — `project(VERSION)`, copy flags, `juce_add_plugin`, artefact copy L614–733]
+- [Source: `CMakeUserPresets.json` — Release presets]
+- [Source: `Source/Shared/Definitions/PluginVersion.cpp`]
+- [External: Luthier `10-2-cd-release-pipeline.md` — publish-ci pattern]
+- [External: Melatonin — codesign/notarize in CI]
+- [External: Pamplejuce — JUCE release workflow reference]
+
+## Change Log
+
+- 2026-07-11 — Story created via create-story workflow: CD release pipeline spec adapted from Luthier 10.2 for JUCE AU/VST3/Standalone + macOS signing.
+- 2026-07-11 — Story 11.2 implemented: release workflow, prepare_release.py, docs, unit tests.
+- 2026-07-11 — Code review: 9 patches applied; story closed.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,5 +1,12 @@
 # Deferred Work
 
+## Deferred from: code review of 11-2-cd-release-pipeline (2026-07-11)
+
+- **Dry-run E2E (push tag réel + assets GitHub Release)** — post-merge maintainer après configuration des secrets ; déjà documenté story L187.
+- **Windows Authenticode non signé pour v1** — choix spec ; documenté CONTRIBUTING comme acceptable MIT open-source.
+- **macOS arm64-only en CI (pas universal)** — décision spec Dev Notes ; universal optionnel documenté.
+- **Pins pytest/PyYAML sans borne supérieure** — dette mineure reproductibilité locale/CI.
+
 ## Deferred from: code review of 11-1-ci-multi-platform-build-and-tests (2026-07-11)
 
 - **Hard-coded test_binary paths per OS in CI workflow** — fragile if CMake output layout changes; consider ctest or artifact discovery later.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,5 +1,14 @@
 # Deferred Work
 
+## Deferred from: code review of 11-1-ci-multi-platform-build-and-tests (2026-07-11)
+
+- **Hard-coded test_binary paths per OS in CI workflow** — fragile if CMake output layout changes; consider ctest or artifact discovery later.
+- **COPY_* CACHE FORCE may retain stale copy flags on local reconfigure** — CI mitigated by fresh checkout each run.
+- **CONTRIBUTING.md entire TOC uses claude.ai URLs instead of in-repo anchors** — pre-existing; fix holistically in doc hygiene pass.
+- **Thread::sleep(50) in MidiManagerTests queue timing** — pre-existing potential CI flakiness under load.
+- **Personal Dropbox artefact paths in CMakeUserPresets.json** — copy disabled in CI; optional ci-* presets deferred.
+- **MIDI-dependent tests skip silently when no output device** — acceptable for AC3 headless CI; mock coverage deferred.
+
 - **Panel M change leaves R list stale until processor hook** — resolved 1+2: sync reads APVTS in 6.6; 7.4 processor calls `syncHistoryUiProperties` on `kSelectedM` change for full panel UX.
 
 ## Deferred from: code review of 7-4-mutatoractionhandler (2026-06-20)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-29
-# last_updated: 2026-07-11 (Story 11-1 code review → done)
+# last_updated: 2026-07-11 (Story 11-2 code review → done)
 # project: Matrix-Control
 # project_key: NOKEY
 # tracking_system: file-system
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-05-29
-last_updated: 2026-07-11 (Story 11-1 code review → done)
+last_updated: 2026-07-11 (Story 11-2 code review → done)
 project: Matrix-Control
 project_key: NOKEY
 tracking_system: file-system
@@ -196,5 +196,5 @@ development_status:
   # Epic 11: CI & Release Infrastructure (Correct Course 2026-07-11)
   epic-11: in-progress
   11-1-ci-multi-platform-build-and-tests: done
-  11-2-cd-release-pipeline: backlog
+  11-2-cd-release-pipeline: done
   epic-11-retrospective: optional

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-29
-# last_updated: 2026-07-11 (Story 11-1 CI workflow — review)
+# last_updated: 2026-07-11 (Story 11-1 code review → done)
 # project: Matrix-Control
 # project_key: NOKEY
 # tracking_system: file-system
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-05-29
-last_updated: 2026-07-11 (Story 11-1 CI workflow — review)
+last_updated: 2026-07-11 (Story 11-1 code review → done)
 project: Matrix-Control
 project_key: NOKEY
 tracking_system: file-system
@@ -195,6 +195,6 @@ development_status:
 
   # Epic 11: CI & Release Infrastructure (Correct Course 2026-07-11)
   epic-11: in-progress
-  11-1-ci-multi-platform-build-and-tests: review
+  11-1-ci-multi-platform-build-and-tests: done
   11-2-cd-release-pipeline: backlog
   epic-11-retrospective: optional


### PR DESCRIPTION
## Summary

- Add `release.yml`: tag-triggered Release builds on macOS/Windows/Linux, macOS sign/notarize, GitHub Release publish
- Add `Scripts/release/prepare_release.py` (pack, finalize, publish-ci, validate-tag) with unit tests
- Run release script tests in `build-and-test` CI before the multi-platform matrix
- Document releasing in CONTRIBUTING; link GitHub Releases in README
- Includes Story 11-1 post-merge review fixes (`ab0a263`) not yet on `origin/main`

## Test plan

- [ ] CI `release-script-tests` job passes
- [ ] CI `build-and-test` matrix passes (macOS / Windows / Linux)
- [ ] After merge: configure macOS signing secrets before first release tag push


Made with [Cursor](https://cursor.com)