### PR TITLE
Add CI build-time optimizations for draft PR fast tier (Story 11-3)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,5 @@
 # Multi-platform build + Core unit tests (Story 11.1).
-# Matrix: ubuntu-latest, windows-latest, macos-latest (fail-fast: false — Luthier 10.1 pattern).
+# Story 11.3: draft PR fast tier (macOS only) + ci-success merge gate.
 #
 # Preset choices (CMakeUserPresets.json):
 #   macOS  — macos-debug-arm64   (Ninja, Apple Silicon runner = macos-latest)
@@ -18,6 +18,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 env:
   JUCE_VERSION: "8.0.12"
@@ -35,27 +36,55 @@ jobs:
           python3 -m pip install -r Scripts/release/requirements-test.txt
           python3 -m pytest Scripts/release/tests/ -q
 
-  build-and-test:
+  resolve-ci-tier:
     needs: release-script-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
+      tier: ${{ steps.resolve.outputs.tier }}
+    steps:
+      - id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          macos='{"os":"macos-latest","preset":"macos-debug-arm64","build_config":"","test_binary":"Builds/macOS/ARM/Debug/Matrix-Control_Tests_artefacts/Debug/Matrix-Control_Tests"}'
+          windows='{"os":"windows-latest","preset":"windows-debug","build_config":"--config Debug","test_binary":"Builds/Windows/Matrix-Control_Tests_artefacts/Debug/Matrix-Control_Tests.exe"}'
+          linux='{"os":"ubuntu-latest","preset":"linux-debug","build_config":"","test_binary":"Builds/Linux/Debug/Matrix-Control_Tests_artefacts/Debug/Matrix-Control_Tests"}'
+
+          tier="full"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            pr_json="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json isDraft,labels)"
+            is_draft="$(echo "$pr_json" | jq -r '.isDraft')"
+            has_ci_full="$(echo "$pr_json" | jq -r '[.labels[].name] | any(. == "ci-full")')"
+
+            if [ "$is_draft" = "true" ] && [ "$ACTION" != "ready_for_review" ] && [ "$has_ci_full" != "true" ]; then
+              tier="fast"
+            fi
+          fi
+
+          if [ "$tier" = "fast" ]; then
+            matrix="{\"include\":[${macos}]}"
+          else
+            matrix="{\"include\":[${macos},${windows},${linux}]}"
+          fi
+
+          echo "tier=${tier}" >> "$GITHUB_OUTPUT"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
+  build-and-test:
+    needs: [release-script-tests, resolve-ci-tier]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            preset: macos-debug-arm64
-            build_config: ""
-            test_binary: Builds/macOS/ARM/Debug/Matrix-Control_Tests_artefacts/Debug/Matrix-Control_Tests
-          - os: windows-latest
-            preset: windows-debug
-            build_config: --config Debug
-            test_binary: Builds/Windows/Matrix-Control_Tests_artefacts/Debug/Matrix-Control_Tests.exe
-          - os: ubuntu-latest
-            preset: linux-debug
-            build_config: ""
-            test_binary: Builds/Linux/Debug/Matrix-Control_Tests_artefacts/Debug/Matrix-Control_Tests
-
+      matrix: ${{ fromJSON(needs.resolve-ci-tier.outputs.matrix) }}
     steps:
       - name: Checkout Matrix-Control
         uses: actions/checkout@v4
@@ -123,3 +152,19 @@ jobs:
         run: |
           test -f "${{ matrix.test_binary }}"
           "${{ matrix.test_binary }}"
+
+  ci-success:
+    name: ci-success
+    needs: [release-script-tests, resolve-ci-tier, build-and-test]
+    if: >-
+      always() &&
+      needs.release-script-tests.result == 'success' &&
+      needs.resolve-ci-tier.result == 'success' &&
+      needs.build-and-test.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: All CI legs passed
+        run: |
+          echo "CI tier: ${{ needs.resolve-ci-tier.outputs.tier }}"
+          echo "All required CI legs passed."

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,6 +46,7 @@ jobs:
     steps:
       - id: resolve
         env:
+          GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,9 +100,39 @@ Familiarity with the following is recommended:
 
 ## Continuous Integration
 
-Every **push** and **pull request** targeting `main` runs the [Build and Test](https://github.com/tensquaresoftware/matrix-control/actions/workflows/build-and-test.yml) workflow on GitHub Actions.
+Every **push** to `main` and every **pull request** targeting `main` runs the [Build and Test](https://github.com/tensquaresoftware/matrix-control/actions/workflows/build-and-test.yml) workflow on GitHub Actions.
 
-### Matrix
+### CI tiers (Story 11.3)
+
+| Trigger | Jobs | Typical duration |
+|---------|------|------------------|
+| **Draft PR** — `opened`, `synchronize`, `reopened` while draft | `release-script-tests` + macOS Debug build/tests | ~5 min |
+| **Ready for review** — non-draft PR, `ready_for_review`, or label **`ci-full`** | `release-script-tests` + full 3-OS matrix | ~12 min |
+| **Push to `main`** (post-merge) | Always full 3-OS matrix | ~12 min |
+
+During active development, open PRs as **draft** to use the fast tier. Mark the PR **ready for review** (or add the `ci-full` label) before merge — the full cross-platform matrix must pass.
+
+**Merge gate:** branch protection requires **`release-script-tests`** and **`ci-success`** (aggregate job). The three matrix leg names are informational only and must not be required checks (they change if workflow matrix parameters change).
+
+**Solo maintainer tip:** `dev-story` → local macOS tests → `code-review` can run in parallel with CI; merge only when Checks are green.
+
+To request a full matrix re-run without toggling draft state, add the **`ci-full`** label to the PR.
+
+### Branch protection update (maintainers)
+
+After the first successful run that includes the `ci-success` job on the Story 11-3 PR (before merge), update required status checks:
+
+```bash
+gh api repos/tensquaresoftware/matrix-control/branches/main/protection/required_status_checks \
+  -X PATCH \
+  -f strict=true \
+  -f 'contexts[]=release-script-tests' \
+  -f 'contexts[]=ci-success'
+```
+
+Remove any legacy required checks named `build-and-test (...)` (truncated matrix job names from Story 11.1–11.2).
+
+### Matrix (full tier)
 
 | Runner | CMake preset | Toolchain |
 |--------|--------------|-----------|

--- a/Scripts/release/tests/test_build_and_test_workflow.py
+++ b/Scripts/release/tests/test_build_and_test_workflow.py
@@ -84,4 +84,5 @@ def test_resolve_tier_logic_documented_in_workflow():
     assert 'tier="fast"' in workflow_text or "tier=fast" in workflow_text
     assert "ready_for_review" in workflow_text
     assert "gh pr view" in workflow_text
+    assert "GH_TOKEN" in workflow_text
     assert 'any(. == "ci-full")' in workflow_text

--- a/Scripts/release/tests/test_build_and_test_workflow.py
+++ b/Scripts/release/tests/test_build_and_test_workflow.py
@@ -1,0 +1,87 @@
+"""Structure tests for .github/workflows/build-and-test.yml (Story 11.3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+BUILD_AND_TEST_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "build-and-test.yml"
+RELEASE_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _load_workflow(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_build_and_test_workflow_structure():
+    workflow_text = BUILD_AND_TEST_WORKFLOW.read_text(encoding="utf-8")
+    workflow = _load_workflow(BUILD_AND_TEST_WORKFLOW)
+    triggers = workflow.get("on") or workflow.get(True) or {}
+
+    assert "push" in triggers
+    assert triggers["push"]["branches"] == ["main"]
+    assert "pull_request" in triggers
+    assert triggers["pull_request"]["branches"] == ["main"]
+    pr_types = triggers["pull_request"]["types"]
+    assert "ready_for_review" in pr_types
+    assert "synchronize" in pr_types
+    assert "labeled" in pr_types
+
+    jobs = workflow["jobs"]
+    assert set(jobs) >= {
+        "release-script-tests",
+        "resolve-ci-tier",
+        "build-and-test",
+        "ci-success",
+    }
+
+    assert jobs["resolve-ci-tier"]["needs"] == "release-script-tests"
+    assert "matrix" in jobs["resolve-ci-tier"]["outputs"]
+    assert "tier" in jobs["resolve-ci-tier"]["outputs"]
+
+    build_job = jobs["build-and-test"]
+    assert build_job["needs"] == ["release-script-tests", "resolve-ci-tier"]
+    assert "fromJSON(needs.resolve-ci-tier.outputs.matrix)" in str(
+        build_job["strategy"]["matrix"]
+    )
+    assert build_job["strategy"]["fail-fast"] is False
+
+    ci_success = jobs["ci-success"]
+    assert ci_success["name"] == "ci-success"
+    assert ci_success["needs"] == [
+        "release-script-tests",
+        "resolve-ci-tier",
+        "build-and-test",
+    ]
+    assert "needs.build-and-test.result == 'success'" in ci_success["if"]
+
+    assert "macos-debug-arm64" in workflow_text
+    assert "windows-debug" in workflow_text
+    assert "linux-debug" in workflow_text
+    assert "MATRIX_BUILD_TESTS=ON" in workflow_text
+    assert "USER_COPY_TO_SYSTEM_FOLDERS=OFF" in workflow_text
+    assert "USER_COPY_TO_ARTEFACTS_DIR=OFF" in workflow_text
+
+
+def test_release_workflow_unchanged_by_story_11_3():
+    """AC6 regression guard: release.yml must not be modified by Story 11.3."""
+    release_text = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+    release = _load_workflow(RELEASE_WORKFLOW)
+    triggers = release.get("on") or release.get(True) or {}
+
+    assert "pull_request" not in triggers
+    assert "tags" in triggers["push"]
+    assert "v*.*.*" in triggers["push"]["tags"]
+    assert set(release["jobs"]) == {"validate-tag", "build", "publish"}
+    assert "notarytool submit" in release_text
+
+
+def test_resolve_tier_logic_documented_in_workflow():
+    workflow_text = BUILD_AND_TEST_WORKFLOW.read_text(encoding="utf-8")
+    assert "ci-full" in workflow_text
+    assert 'tier="fast"' in workflow_text or "tier=fast" in workflow_text
+    assert "ready_for_review" in workflow_text
+    assert "gh pr view" in workflow_text
+    assert 'any(. == "ci-full")' in workflow_text

--- a/_bmad-output/implementation-artifacts/11-3-ci-build-time-optimizations.md
+++ b/_bmad-output/implementation-artifacts/11-3-ci-build-time-optimizations.md
@@ -3,7 +3,7 @@ organization: Ten Square Software
 project: Matrix-Control
 title: Story 11.3 — CI Build-Time Optimizations
 author: BMad Agent
-status: ready-for-dev
+status: review
 epic: 11
 story: 3
 story_key: 11-3-ci-build-time-optimizations
@@ -25,7 +25,7 @@ updated: 2026-07-11
 
 # Story 11.3: CI Build-Time Optimizations
 
-Status: ready-for-dev
+Status: review
 
 <!-- Epic 11 — CI & Release Infrastructure. Flow ergonomics story: faster PR CI without weakening the 3-OS merge gate. Does NOT modify release.yml (Story 11.2). -->
 
@@ -112,16 +112,26 @@ So that the dev → PR → review → merge loop stays practical on a solo maint
 
 ## Tasks / Subtasks
 
-- [ ] Record baseline per job in Dev Agent Record (reuse PR #21 / #22 numbers; re-measure after 11-2 `release-script-tests` job)
-- [ ] Implement Lever **B** — draft/fast vs full matrix split in `build-and-test.yml` (AC: 1, 2, 3)
-- [ ] Implement Lever **F** — `ci-success` job + update `main` branch protection via `gh api` or documented manual steps (AC: 3, 4)
+- [x] Record baseline per job in Dev Agent Record (reuse PR #21 / #22 numbers; re-measure after 11-2 `release-script-tests` job)
+- [x] Implement Lever **B** — draft/fast vs full matrix split in `build-and-test.yml` (AC: 1, 2, 3)
+- [x] Implement Lever **F** — `ci-success` job + update `main` branch protection via `gh api` or documented manual steps (AC: 3, 4)
 - [ ] (Optional) Implement Lever **D** on fast tier — tests-only target (AC: 2, 3)
 - [ ] (Optional) Implement Lever **C** — path filters for docs-only PRs (AC: 3)
 - [ ] (Optional) Implement Lever **A** or **E** — compile/configure cache (AC: 2, 3)
-- [ ] Extend workflow structure tests (AC: 7)
-- [ ] Update `CONTRIBUTING.md` CI section (AC: 5)
-- [ ] Validate on a test PR: cold + warm run; capture timings in Dev Agent Record (AC: 2)
-- [ ] Resolve or defer 11-1 review item: hard-coded `test_binary` paths (consider `ctest` or `cmake --build --target run_tests` if added)
+- [x] Extend workflow structure tests (AC: 7)
+- [x] Update `CONTRIBUTING.md` CI section (AC: 5)
+- [ ] Validate on a test PR: cold + warm run; capture timings in Dev Agent Record (AC: 2) — **Flow B: pending single push post code-review**
+- [x] Resolve or defer 11-1 review item: hard-coded `test_binary` paths (consider `ctest` or `cmake --build --target run_tests` if added) — **deferred**: paths centralized in `resolve-ci-tier` JSON; `ctest` out of scope for v1
+
+### Review Findings
+
+- [x] [Review][Decision] AC2 — valider les timings avant de clôturer la story — **reporté au premier push PR** (Flow B) ; story reste `review` jusqu’aux mesures cold/warm dans Dev Agent Record.
+- [x] [Review][Decision] AC4 — moment de la migration branch protection — **après premier run vert sur la PR 11-3** (ordre : push → CI verte → `gh api` → merge).
+- [x] [Review][Decision] AC7 — profondeur des tests tier — **reporté v1** ; `gh pr view` + `jq` dans le workflow couvre re-run stale et détection label ; tests structurels suffisants pour ce sprint.
+- [x] [Review][Patch] Trigger `labeled` manquant — ajouté `labeled` + `unlabeled` [`.github/workflows/build-and-test.yml:21`]
+- [x] [Review][Patch] Re-run workflow avec payload stale — `resolve-ci-tier` lit l’état live via `gh pr view` [`.github/workflows/build-and-test.yml:47-71`]
+- [x] [Review][Patch] Détection label `ci-full` par grep fragile — remplacé par `jq` exact match [`.github/workflows/build-and-test.yml:64`]
+- [x] [Review][Defer] PRs de fork — l’auteur ne peut pas ajouter `ci-full` sans maintainer [`.github/workflows/build-and-test.yml:64`] — deferred, limitation GitHub Actions
 
 ## Dev Notes
 
@@ -244,13 +254,53 @@ Currently required on `main` (set during Story 11-2 review cleanup):
 
 ### Agent Model Used
 
-_(unset — story not started)_
+Composer (dev-story Flow B)
 
 ### Debug Log References
 
+- `python3 -m pytest Scripts/release/tests/ -q` — 22 passed
+- macOS `Matrix-Control_Tests` — existing binary ran green (JUCE not at `/Applications/JUCE`; configure skipped)
+
+### Baseline timings (before 11.3, PR #21 + 11.2 overhead)
+
+| Job | Duration | Notes |
+|-----|----------|-------|
+| `release-script-tests` | ~7 s | Added in 11.2 |
+| macOS matrix leg | ~5 min 17 s | PR #21 |
+| Linux matrix leg | ~9 min 01 s | PR #21 |
+| Windows matrix leg | ~12 min 23 s | PR #21 — **wall clock** |
+| **Full PR total** | **~12 min** | 3 parallel legs |
+
+**After 11.3 (expected, not yet measured on GitHub):**
+
+| Tier | Expected |
+|------|----------|
+| Draft PR (fast) | ~5 min (macOS + release-script-tests) |
+| Ready for review / push `main` | ~12 min (unchanged full gate) |
+
+After timings: capture on the single Flow B PR push (cold run ready-for-review; optional warm re-run via `ci-full` label).
+
 ### Completion Notes List
 
+- Lever **B**: `resolve-ci-tier` job outputs dynamic matrix — macOS-only when `pull_request` + draft + not `ready_for_review` + no `ci-full` label; full 3-OS otherwise (including all `push` to `main`).
+- Lever **F**: `ci-success` aggregate job; branch protection migration documented in `CONTRIBUTING.md` (`gh api` payload).
+- Optional levers A/C/D/E skipped for v1 (B alone meets fast-tier target).
+- `test_binary` paths consolidated in `resolve-ci-tier` shell (single SSOT within workflow); still hard-coded strings — `ctest` deferred.
+- **Flow B:** no push yet; AC2 after-timings pending PR validation.
+- **Code review (2026-07-11):** patches applied — `labeled`/`unlabeled` triggers, live PR state via `gh pr view`, `jq` exact `ci-full` match; AC2/AC4 deferred per review decisions.
+
 ### File List
+
+- `.github/workflows/build-and-test.yml` (modified)
+- `Scripts/release/tests/test_build_and_test_workflow.py` (added)
+- `CONTRIBUTING.md` (modified)
+- `_bmad-output/implementation-artifacts/11-3-ci-build-time-optimizations.md` (modified)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+
+### Change Log
+
+- 2026-07-11 — Story 11.3 created: CI build-time optimizations + `ci-success` branch protection lever after 7-5 PR ~12 min observation and main protection setup.
+- 2026-07-11 — Implemented Lever B (draft fast tier) + F (`ci-success`); workflow structure tests; CONTRIBUTING CI tiers (Flow B, no push).
 
 ## References
 

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,5 +1,9 @@
 # Deferred Work
 
+## Deferred from: code review of 11-3-ci-build-time-optimizations (2026-07-11)
+
+- **PRs de fork — l’auteur ne peut pas ajouter `ci-full` sans maintainer** — limitation GitHub Actions ; documenter dans CONTRIBUTING si friction observée.
+
 ## Deferred from: code review of 11-2-cd-release-pipeline (2026-07-11)
 
 - **Dry-run E2E (push tag réel + assets GitHub Release)** — post-merge maintainer après configuration des secrets ; déjà documenté story L187.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-05-29
-# last_updated: 2026-07-11 (Story 7-5 merged; 11-3 create-story → ready-for-dev)
+# last_updated: 2026-07-11 (Story 11-3 dev-story → review, Flow B no push)
 # project: Matrix-Control
 # project_key: NOKEY
 # tracking_system: file-system
@@ -41,7 +41,7 @@
 # - Retrospective appends its action items to action_items; sprint-status surfaces open ones
 
 generated: 2026-05-29
-last_updated: 2026-07-11 (Story 7-5 merged; 11-3 create-story → ready-for-dev)
+last_updated: 2026-07-11 (Story 11-3 dev-story → review, Flow B no push)
 project: Matrix-Control
 project_key: NOKEY
 tracking_system: file-system
@@ -197,5 +197,5 @@ development_status:
   epic-11: in-progress
   11-1-ci-multi-platform-build-and-tests: done
   11-2-cd-release-pipeline: done
-  11-3-ci-build-time-optimizations: ready-for-dev
+  11-3-ci-build-time-optimizations: review
   epic-11-retrospective: optional


### PR DESCRIPTION
## Summary

- Add **Lever B**: draft PRs run a fast CI tier (macOS only + `release-script-tests`); full 3-OS matrix runs on ready-for-review, `ci-full` label, or push to `main`
- Add **Lever F**: `ci-success` aggregate job for a stable merge gate (replaces fragile truncated matrix check names)
- Resolve tier from **live PR state** via `gh pr view` + `jq` (handles re-runs and `ci-full` label without extra pushes)
- Document CI tiers and branch-protection migration steps in `CONTRIBUTING.md`
- Add workflow structure tests under `Scripts/release/tests/`

## Test plan

- [ ] Draft PR triggers fast tier (~5 min): `release-script-tests` + macOS matrix leg only
- [ ] Mark ready for review triggers full 3-OS matrix (~12 min)
- [ ] `ci-full` label on draft PR triggers full matrix without toggling draft
- [ ] After first green run: migrate branch protection to `release-script-tests` + `ci-success` (`gh api` in CONTRIBUTING.md)
- [ ] Capture cold/warm timings in story Dev Agent Record (AC2)
- [ ] Confirm `release.yml` unchanged (AC6)

## Post-merge (maintainer)

Run the `gh api` branch protection update documented in CONTRIBUTING.md § Branch protection update after the first successful `ci-success` on this PR.


Made with [Cursor](https://cursor.com)